### PR TITLE
Migrate to Play age-signals 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.8.0
+
+* **Android**: Updated `com.google.android.play:age-signals` from 0.0.3 to 0.0.4, which removes the library's `userStatus` and replaces it with `ageRangeSource` + `significantChangeStatus`. The plugin derives the existing `AgeSignalsStatus` vocabulary from the new pair (Google's release notes name it as the official replacement), so `status`-based code keeps working unchanged.
+* **Android**: Added `requestAgeSignalsAccess()`, the first half of the 0.0.4 two-call flow. It may show Play's in-app age sharing prompt (the plugin now implements `ActivityAware` to present it) and returns an `AgeSignalsAccessStatus`: `shared`, `notShared` (a decline is not an error), or `verificationRequired` (mandatory-verification regions; the user verifies in the Play Store). Call it before `checkAgeSignals()` and only read signals on `shared`. On iOS it returns `shared` without showing anything - Apple gathers consent inside `checkAgeSignals()` itself - so one call sequence works on both platforms.
+* **Android**: `AgeSignalsResult` now exposes `ageRangeSource` (tierA self-declared, tierB parent-managed, tierC/tierD verified) and `significantChangeStatus` (approved/pending/declined, supervised users).
+* **Breaking**: Renamed `AgeSignalsResult.mostRecentApprovalDate` to `significantChangeApprovalDate`, following the same rename in age-signals 0.0.4 (it is the effective date of the most recently approved significant change). The `AgeSignalsMockData` field and channel key are renamed in lockstep.
+* **Android**: `AgeSignalsMockData` gained `accessStatus` (mock outcome of the access request, defaults to `shared`) and explicit `ageRangeSource` / `significantChangeStatus` overrides; when omitted, both are derived from `status`, so existing mocks round-trip unchanged. Explicit `ageLower`/`ageUpper` are now honored for verified mocks too, matching the real API's open-ended 18+ band (`ageLower: 18, ageUpper: null`).
+* **Docs**: Documented the two-call architecture, the new enums, `installId`'s role in revoked app approvals (Play Console CSV, 90-day retention), and Play's prompt-suppression behavior after repeated dismissals.
+* **Example**: Added a "Request Age Signals Access" step, an "Access Not Shared" scenario chip, and result rows for the new fields.
+
 ## 0.7.0
 
 * **iOS**: Added `getRequiredRegulatoryFeatures()` (iOS 26.4+), which reports whether Apple requires the current user to share an age range and whether significant-change notification or parental consent applies (#31). Calls are guarded by a 10-second deadline. Throws `UnsupportedPlatformException` below iOS 26.4 (and in apps built with an SDK older than iOS 26.4) so an empty set always means Apple affirmatively reports nothing is required; on Android the set is always empty.
@@ -102,7 +112,7 @@
 ## 0.2.0
 
 * **Android**: ⚠️ **CRITICAL UPDATE** - Bumped Play Age Signals API library version to non-beta stable release `com.google.android.play:age-signals:0.0.1` (thanks to @rokarnus for reporting this in #5)
-  
+
 * **ACTION REQUIRED**: Users must upgrade to version 0.2.0 or higher before January 1, 2026
   * **Why**: From January 1, 2026, all beta versions (0.0.1-beta*) of the Play Age Signals API will throw exceptions
   * **Impact**: Apps using older versions of this plugin (with beta API) will stop working after January 1, 2026

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ A Flutter plugin for age verification that supports Google Play Age Signals API 
     - [AgeSignalsMockData](#agesignalsmockdata)
     - [AgeSignalsResult](#agesignalsresult)
     - [AgeSignalsStatus](#agesignalsstatus)
+    - [AgeSignalsAccessStatus](#agesignalsaccessstatus)
+    - [AgeRangeSource](#agerangesource)
+    - [SignificantChangeStatus](#significantchangestatus)
     - [AgeDeclarationSource](#agedeclarationsource)
     - [AgeRegulatoryFeature](#ageregulatoryfeature)
     - [Exceptions](#exceptions)
@@ -46,7 +49,7 @@ A Flutter plugin for age verification that supports Google Play Age Signals API 
 ## Features
 
 - ✅ Cross-platform support for Android and iOS
-- ✅ Google Play Age Signals API integration for Android (API 23+)
+- ✅ Google Play Age Signals API integration for Android (API 23+), including the age sharing prompt via `requestAgeSignalsAccess()` (age-signals 0.0.4)
 - ✅ Apple DeclaredAgeRange API integration for iOS (26.0+)
 - ✅ Regulatory feature detection and significant update acknowledgment for iOS (26.4+)
 - ✅ Swift Package Manager (SPM) support for iOS
@@ -73,7 +76,7 @@ The plugin returns one age signal; how far you build on it depends on your app, 
 
 | Level | Who it's for | What you do with the plugin |
 |-------|--------------|-----------------------------|
-| **1. Minimal** | Generally-available apps, no age-gated content | Call `checkAgeSignals()` once, optionally log the result, leave the UX unchanged. See [Generally Available App](#generally-available-app-no-age-restrictions). |
+| **1. Minimal** | Generally-available apps, no age-gated content | Call `requestAgeSignalsAccess()` then `checkAgeSignals()` once, optionally log the result, leave the UX unchanged. See [Generally Available App](#generally-available-app-no-age-restrictions). |
 | **2. Targeted** | Apps with age-distinct areas (under/over 18, or 18+ only) | Gate those areas on `status` and the returned age range. See [Basic Example](#basic-example) and [18+ Only App](#18-only-app). |
 | **3. Full** | Apps squarely in scope of these laws | Treat the client signal as one input: enforce on your **server** (the client result can be spoofed), re-check when state changes, and handle every `status` and [exception](#exceptions). |
 
@@ -81,9 +84,9 @@ The plugin returns one age signal; how far you build on it depends on your app, 
 
 These laws are in flux. The plugin handles missing data gracefully, so the advice is the same throughout: keep it integrated and rely on the runtime signal rather than hard-coding which regions are live. Dates are current as of this release.
 
-- **Brazil (Lei 15.211, Digital ECA):** Enforceable since March 17, 2026. Requires `com.google.android.play:age-signals` 0.0.3+, which this plugin bundles. [Law](https://www.planalto.gov.br/ccivil_03/_ato2023-2026/2025/lei/L15211.htm) · [Google docs](https://support.google.com/googleplay/android-developer/answer/6223646?hl=en#digital_eca_requirements)
+- **Brazil (Lei 15.211, Digital ECA):** Enforceable since March 17, 2026. Requires `com.google.android.play:age-signals` 0.0.3+; this plugin bundles 0.0.4. [Law](https://www.planalto.gov.br/ccivil_03/_ato2023-2026/2025/lei/L15211.htm) · [Google docs](https://support.google.com/googleplay/android-developer/answer/6223646?hl=en#digital_eca_requirements)
 - **Australia:** An applicable region for Apple's DeclaredAgeRange API. From February 24, 2026, Apple blocks users in Australia from downloading 18+ apps unless confirmed adult. Separate from the [Social Media Minimum Age Act](https://www.esafety.gov.au/about-us/industry-regulation/social-media-age-restrictions) (in effect December 10, 2025), and from App Store content *ratings*, which this plugin does not handle. [Apple News](https://developer.apple.com/news/?id=f5zj08ey)
-- **Texas (SB 2420):** In effect since June 4, 2026 under a [temporary Fifth Circuit stay](https://www.texastribune.org/2026/05/28/texas-apple-google-app-store-age-verification/) of the December 2025 injunction, so the APIs may return live data for Texas users. This is not a final ruling and could be re-blocked. **Utah** delayed to May 2027 ([HB 498](https://technologylaw.fkks.com/post/102mpap/utah-first-state-to-amend-its-app-store-accountability-act)); **Louisiana** to July 1, 2027 ([HB 977](https://www.alstonprivacy.com/louisiana-delays-app-store-accountability-effective-date-to-july-2027/)). See [Issue #21](https://github.com/zigapovhe/age_range_signals/issues/21).
+- **Texas (SB 2420):** In effect since June 4, 2026 under a [temporary Fifth Circuit stay](https://www.texastribune.org/2026/05/28/texas-apple-google-app-store-age-verification/) of the December 2025 injunction. Google reports the Play Age Signals API returns signals for eligible Texas users whose accounts were created after May 28, 2026. This is not a final ruling and could be re-blocked. **Utah** delayed to May 2027 ([HB 498](https://technologylaw.fkks.com/post/102mpap/utah-first-state-to-amend-its-app-store-accountability-act)); **Louisiana** to July 1, 2027 ([HB 977](https://www.alstonprivacy.com/louisiana-delays-app-store-accountability-effective-date-to-july-2027/)). See [Issue #21](https://github.com/zigapovhe/age_range_signals/issues/21).
 
 ## Platform Setup
 
@@ -94,6 +97,8 @@ These laws are in flux. The plugin handles missing data gracefully, so the advic
 2. The Play Age Signals API requires Google Play Services to be installed and up to date.
 
 3. The plugin builds on AGP 9 (built-in Kotlin) as well as AGP 8.x, where it needs the Kotlin Gradle plugin 2.0 or newer on your project's classpath (any recent Flutter template already provides this).
+
+4. Since age-signals 0.0.4, Google Play splits age signals across two calls: `requestAgeSignalsAccess()` asks for access - showing Play's in-app age sharing prompt when the user's Play settings call for asking first - and `checkAgeSignals()` then reads the signals. Call the access request before checking, and only read signals when it returns `AgeSignalsAccessStatus.shared`. The prompt presents over your app's activity; the plugin obtains it automatically, but calling from a headless context (no foreground activity) fails with `PRESENTATION_CONTEXT_UNAVAILABLE`.
 
 **Important:** The Play Age Signals API is currently in beta and only returns real data for users in regions where the underlying laws are in effect; see [Regulatory Status](#regulatory-status) for current dates. Use `useMockData: true` for testing otherwise.
 
@@ -137,6 +142,16 @@ await AgeRangeSignals.instance.initialize(ageGates: [13, 16, 18]);
 
 // Check age signals
 try {
+  // Ask for access first (Android shows Play's age sharing prompt when
+  // needed; iOS always reports shared and gathers consent in the check).
+  final access = await AgeRangeSignals.instance.requestAgeSignalsAccess();
+  if (access != AgeSignalsAccessStatus.shared) {
+    // notShared: user or parent declined - not an error, just no signals.
+    // verificationRequired: user must verify in the Play Store first.
+    print('No age signals to read: $access');
+    return;
+  }
+
   final result = await AgeRangeSignals.instance.checkAgeSignals();
 
   switch (result.status) {
@@ -165,9 +180,10 @@ try {
 
   // Access age range (both platforms)
   // iOS: Available when user consents to share
-  // Android: Available for supervised users
-  if (result.ageLower != null && result.ageUpper != null) {
-    print('Age range: ${result.ageLower} - ${result.ageUpper}');
+  // Android: Available whenever signals are shared
+  // ageUpper is null for the open-ended 18+ band, so check ageLower alone.
+  if (result.ageLower != null) {
+    print('Age range: ${result.ageLower} - ${result.ageUpper ?? "open-ended"}');
   }
 
   // Android-specific: Access install ID
@@ -222,6 +238,13 @@ Future<void> checkUserAge() async {
 
   // Check age signals
   try {
+    final access = await AgeRangeSignals.instance.requestAgeSignalsAccess();
+    if (access != AgeSignalsAccessStatus.shared) {
+      // No signals available; decide your fallback (e.g. restrict or prompt).
+      showAgeVerificationPrompt();
+      return;
+    }
+
     final result = await AgeRangeSignals.instance.checkAgeSignals();
 
     if (result.status == AgeSignalsStatus.verified) {
@@ -286,6 +309,13 @@ If your app is strictly 18+, set a single gate at 18 so the API classifies the u
 // iOS only: one gate at 18
 await AgeRangeSignals.instance.initialize(ageGates: [18]);
 
+final access = await AgeRangeSignals.instance.requestAgeSignalsAccess();
+if (access != AgeSignalsAccessStatus.shared) {
+  // Block; on verificationRequired, point the user at the Play Store
+  // to complete verification.
+  return;
+}
+
 final result = await AgeRangeSignals.instance.checkAgeSignals();
 if (result.status == AgeSignalsStatus.verified) {
   // User meets 18+ requirement
@@ -312,6 +342,13 @@ Future<void> initAgeSignals() async {
 
 Future<void> requestAgeSignals() async {
   try {
+    final access = await AgeRangeSignals.instance.requestAgeSignalsAccess();
+    if (access != AgeSignalsAccessStatus.shared) {
+      // Optional: log the outcome; nothing to read without shared access
+      print('Age signals access: $access');
+      return;
+    }
+
     final result = await AgeRangeSignals.instance.checkAgeSignals();
     // Optional: log for compliance/analytics (without gating features)
     print('Age signals status: ${result.status}');
@@ -335,7 +372,9 @@ Main class for interacting with the plugin.
   - `useMockData`: (Android only) Set to `true` to use Google's `FakeAgeSignalsManager` for testing. Ignored on iOS. Defaults to `false`.
   - `mockData`: (Android only) Optional custom mock data configuration using Google's official testing utilities. Ignored on iOS. If not provided, defaults to supervised user (13-15).
 
-- `Future<AgeSignalsResult> checkAgeSignals()` - Checks the age signals for the current user.
+- `Future<AgeSignalsAccessStatus> requestAgeSignalsAccess()` - Requests access to the user's age signals (age-signals 0.0.4). On Android this may show Google Play's in-app age sharing prompt over your activity; only call `checkAgeSignals()` when the result is `shared`. A decline is not an error - it comes back as `notShared`. In mandatory-verification regions Play skips the prompt entirely: already-verified and supervised users come back `shared`, while unverified users come back `verificationRequired` and complete verification in the Play Store app. On iOS this always returns `shared` without showing anything, because Apple gathers consent inside `checkAgeSignals()` itself; a refusal surfaces there as `AgeSignalsStatus.declined`.
+
+- `Future<AgeSignalsResult> checkAgeSignals()` - Checks the age signals for the current user. On Android, call `requestAgeSignalsAccess()` first; without shared access the API returns no signals and `status` is `unknown`.
 
 - `Future<Set<AgeRegulatoryFeature>> getRequiredRegulatoryFeatures()` - Returns which regulatory actions Apple requires for the current user (iOS 26.4+). An empty set means Apple affirmatively reports nothing is required; if `declaredAgeRangeRequired` is absent, you are not required to prompt this user. Returns an empty set on Android (the Play API has no equivalent concept). Throws `UnsupportedPlatformException` on iOS below 26.4 and in apps built with a pre-26.4 SDK (Xcode < 26.4), where the requirement cannot be checked.
 
@@ -354,7 +393,10 @@ AgeSignalsMockData({
   int? ageUpper,
   AgeDeclarationSource? source,
   String? installId,
-  DateTime? mostRecentApprovalDate,
+  AgeSignalsAccessStatus? accessStatus,
+  AgeRangeSource? ageRangeSource,
+  SignificantChangeStatus? significantChangeStatus,
+  DateTime? significantChangeApprovalDate,
 })
 ```
 
@@ -365,7 +407,10 @@ AgeSignalsMockData({
 - `int? ageUpper` - Mock upper bound of age range (for supervised statuses)
 - `AgeDeclarationSource? source` - Reserved for future use (currently unused)
 - `String? installId` - Mock installation ID (Android only)
-- `DateTime? mostRecentApprovalDate` - Mock guardian approval date (Android only)
+- `AgeSignalsAccessStatus? accessStatus` - Mock outcome of `requestAgeSignalsAccess()`; defaults to `shared` when null
+- `AgeRangeSource? ageRangeSource` - Explicit mock tier; when null it is derived from `status` (verified maps to `tierC`, declared to `tierA`, the supervised family to `tierB`). The result's `status` is always re-derived from the resolved tier and change status, exactly as with real API responses, so an explicit tier wins over a contradictory `status`
+- `SignificantChangeStatus? significantChangeStatus` - Explicit mock change status; when null it is derived from `status` (`supervisedApprovalPending` maps to `pending`, `supervisedApprovalDenied` to `declined`)
+- `DateTime? significantChangeApprovalDate` - Mock significant change approval date (Android only)
 
 #### Example (Android only)
 
@@ -390,33 +435,37 @@ Result object containing age verification information.
 #### Properties
 
 - `AgeSignalsStatus status` - The verification status
-- `int? ageLower` - Lower bound of age range (both platforms; iOS: when user consents, Android: for supervised users)
-- `int? ageUpper` - Upper bound of age range (both platforms; iOS: when user consents, Android: for supervised users)
+- `int? ageLower` - Lower bound of age range (both platforms; iOS: when user consents, Android: whenever signals are shared - verified 18+ reports `ageLower=18`)
+- `int? ageUpper` - Upper bound of age range (both platforms; iOS: when user consents, Android: whenever signals are shared; `null` for the open-ended 18+ band)
 - `AgeDeclarationSource? source` - Source of age declaration (iOS only)
-- `String? installId` - Installation identifier (Android only)
+- `String? installId` - Installation identifier (Android only, supervised users). When a parent revokes approval, Google lists the id on the Play Console's Revoked app approvals tab as a CSV download retained for 90 days; store it on your backend and ingest revocations within that window if you need to act on them - Google permits no other use
 - `List<String>? activeParentalControls` - Parental controls active on the user's account, as raw Apple identifiers such as `communicationLimits` (iOS only)
-- `DateTime? mostRecentApprovalDate` - When a guardian most recently approved the age range (Android only, supervised users)
+- `AgeRangeSource? ageRangeSource` - How Google Play established the age range (Android only); `status` is derived from this tier together with `significantChangeStatus`
+- `SignificantChangeStatus? significantChangeStatus` - Parent approval state for significant app changes (Android only, supervised users)
+- `DateTime? significantChangeApprovalDate` - Effective date of the most recently approved significant change (Android only, supervised users). Named `mostRecentApprovalDate` before 0.8.0
 
 #### When are ageLower and ageUpper populated?
 
 **Android (Google Play Age Signals API):**
 
-| userStatus | ageLower/ageUpper | installId | Notes |
-|------------|-------------------|-----------|-------|
-| `verified` | `null` / `null` | `null` | User is 18+, no supervision needed |
-| `supervised` | Populated / Populated† | Populated | Supervised account with approved age range |
-| `supervisedApprovalPending` | Populated / Populated† | Populated | Awaiting parent approval for changes |
-| `supervisedApprovalDenied` | Populated / Populated† | Populated | Parent denied changes; use previous approved age |
-| `declared` | Populated / Populated† | `null` | User declared their age through Google Play (Brazil only) |
-| `unknown` | `null` / `null` | `null` | User unverified/unsupervised, or API unavailable in region |
+| status | ageRangeSource | ageLower/ageUpper | installId | Notes |
+|--------|----------------|-------------------|-----------|-------|
+| `verified` | `tierC` / `tierD` | Populated / `null`† | `null` | Verified 18+ reports the open-ended band (`ageLower=18`) |
+| `supervised` | `tierB` | Populated / Populated† | Populated | Parent-managed account with approved age range |
+| `supervisedApprovalPending` | `tierB` | Populated / Populated† | Populated | Awaiting parent approval of a significant change |
+| `supervisedApprovalDenied` | `tierB` | Populated / Populated† | Populated | Parent denied the change; use previous approved state |
+| `declared` | `tierA` | Populated / Populated† | `null` | User declared their age through Google Play (Brazil only) |
+| `unknown` | `null` | `null` / `null` | `null` | Access not shared, verification required, or API unavailable in region |
 
-**†Edge case:** For supervised users, `ageUpper` may be `null` if the parent-attested age is over 18 (e.g., `ageLower=18, ageUpper=null`).
+**†Edge case:** `ageUpper` is `null` for the open-ended 18+ band regardless of tier - verified users always, and supervised users when the parent-attested age is over 18 (e.g., `ageLower=18, ageUpper=null`).
+
+**Note:** age-signals 0.0.4 removed the library's `userStatus`; the plugin derives `status` from `ageRangeSource` + `significantChangeStatus` (their documented replacement), so existing `status`-based code keeps working unchanged.
 
 **Note:** On Android, age ranges are determined by Google Play's parental control settings and returned as predefined age bands (0-12, 13-15, 16-17, 18+). The `ageGates` parameter is **not used** on Android - it's iOS-only. You cannot customize these age bands through the plugin; they're controlled by Google Play and can optionally be customized in Play Console.
 
 **iOS (DeclaredAgeRange API):**
 
-| userStatus | ageLower/ageUpper | source | Notes |
+| status | ageLower/ageUpper | source | Notes |
 |------------|-------------------|--------|-------|
 | `verified` | Populated‡ | Populated§ | User consented; lower bound ≥ highest configured gate |
 | `supervised` | Populated‡ | Populated§ | User consented; lower bound < highest configured gate |
@@ -432,13 +481,39 @@ Result object containing age verification information.
 
 Enum representing the verification status:
 
-- `verified` - User is verified as above age threshold (both platforms)
-- `supervised` - User is under parental supervision (Android) or declared age is below configured age gates (iOS)
-- `supervisedApprovalPending` - User is supervised and awaiting guardian approval (Android only)
-- `supervisedApprovalDenied` - User is supervised and guardian denied approval (Android only)
-- `declared` - User declared their age through Google Play's age declaration flow (Android only)
-- `declined` - User declined to share age (iOS only)
-- `unknown` - Age information not available / user unverified or unsupervised (Android). As of 0.6.0, iOS no longer returns this (see [Regional Eligibility](#regional-eligibility-ios-262))
+- `verified` - User is verified as above age threshold (both platforms; Android: `tierC`/`tierD` age range source)
+- `supervised` - User is under parental supervision (Android: `tierB` with no pending or declined change) or declared age is below configured age gates (iOS)
+- `supervisedApprovalPending` - User is supervised and a significant change awaits parent approval (Android only)
+- `supervisedApprovalDenied` - User is supervised and the parent denied the significant change (Android only)
+- `declared` - User declared their age through Google Play's age declaration flow (Android only, `tierA`)
+- `declined` - User declined to share age (iOS only; on Android a decline surfaces as `AgeSignalsAccessStatus.notShared` from the access request)
+- `unknown` - Age information not available: access not shared or verification required (Android), or the API is unavailable. As of 0.6.0, iOS no longer returns this (see [Regional Eligibility](#regional-eligibility-ios-262))
+
+### AgeSignalsAccessStatus
+
+Enum returned by `requestAgeSignalsAccess()` (age-signals 0.0.4):
+
+- `shared` - Age signals are shared; proceed to `checkAgeSignals()`. Always the answer on iOS, where consent is gathered inside the check itself
+- `notShared` - The user declined or previously chose not to share, a parent rejected sharing, or the user is not eligible. Not an error
+- `verificationRequired` - The user must verify their age in the Play Store app first (mandatory-verification regions, when the age is not already established); Play does not show the in-app prompt
+- `unknown` - Play reported a state this plugin version does not recognize
+
+### AgeRangeSource
+
+Enum describing how Google Play established the age range (Android only, age-signals 0.0.4), ordered from weakest to strongest assurance. The tier vocabulary is Google's own:
+
+- `tierA` - Self-declared by the user
+- `tierB` - From a parent- or guardian-managed account (the supervised family)
+- `tierC` - Verified via credit card, email, selfie, government ID, or tax ID
+- `tierD` - Verified via government ID plus selfie, or a Digital ID
+
+### SignificantChangeStatus
+
+Enum describing parent approval of significant app changes you report on the Play Console's Age signals page (Android only, supervised users). Approval is cumulative: one parent approval covers every change still pending since the last approval:
+
+- `approved` - The parent approved the most recent change(s); `significantChangeApprovalDate` carries the effective date
+- `pending` - Approval requested but not yet answered; restrict the functionality behind the change
+- `declined` - The parent denied the change(s); restrict the functionality behind them
 
 ### AgeDeclarationSource
 
@@ -597,6 +672,25 @@ await AgeRangeSignals.instance.initialize(
     status: AgeSignalsStatus.unknown,
   ),
 );
+
+// Test the access request being declined (requestAgeSignalsAccess()
+// returns notShared; checkAgeSignals() then reports unknown)
+await AgeRangeSignals.instance.initialize(
+  useMockData: true,
+  mockData: const AgeSignalsMockData(
+    status: AgeSignalsStatus.unknown,
+    accessStatus: AgeSignalsAccessStatus.notShared,
+  ),
+);
+
+// Test a strongly verified user (explicit tier override)
+await AgeRangeSignals.instance.initialize(
+  useMockData: true,
+  mockData: const AgeSignalsMockData(
+    status: AgeSignalsStatus.verified,
+    ageRangeSource: AgeRangeSource.tierD,
+  ),
+);
 ```
 
 **Benefits:**
@@ -605,7 +699,7 @@ await AgeRangeSignals.instance.initialize(
 - Easier automated testing and manual QA
 - Default behavior (supervised 13-15) maintained for backward compatibility
 
-**Note**: Mock values follow the same predefined age bands as real responses (`0-12`, `13-15`, `16-17`, `18+`); verified users return `null` for both bounds. See [AgeSignalsResult](#agesignalsresult) for the full rules.
+**Note**: Mock values follow the same predefined age bands as real responses (`0-12`, `13-15`, `16-17`, `18+`). Verified mocks return `null` bounds unless you set them explicitly - a real verified response reports the open-ended 18+ band (`ageLower: 18, ageUpper: null`), so pass `ageLower: 18` to mirror it. See [AgeSignalsResult](#agesignalsresult) for the full rules.
 
 ### iOS Testing
 
@@ -724,6 +818,14 @@ try {
 - Ensure Google Play Services is installed and up to date
 - Verify the device has an active internet connection
 - Check if the user is in a region where the law is currently in effect (see [Regulatory Status](#regulatory-status))
+
+**PRESENTATION_CONTEXT_UNAVAILABLE**
+- `requestAgeSignalsAccess()` was called with no foreground activity to present Play's age sharing prompt on (e.g. from a background isolate or before the first frame)
+- Call it from a foregrounded app; the plugin picks up the activity automatically
+
+**Prompt never appears from `requestAgeSignalsAccess()`**
+- The prompt is only shown to unsupervised users whose Play setting is "Ask before sharing"; "Always share" and "Never share" resolve silently, parents manage sharing for supervised users via Family Link, and in mandatory-verification regions unverified users get `verificationRequired` instead of a prompt
+- After repeated dismissals Play suppresses the prompt and keeps answering `notShared`
 
 **iOS**
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ android {
     }
 
     dependencies {
-        implementation("com.google.android.play:age-signals:0.0.3")
+        implementation("com.google.android.play:age-signals:0.0.4")
         // Explicit artifact + version: KGP's test-framework auto-selection is
         // unavailable when AGP 9 built-in Kotlin is active.
         testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:2.2.20")

--- a/android/src/main/kotlin/si/povhe/age_range_signals/AgeRangeSignalsPlugin.kt
+++ b/android/src/main/kotlin/si/povhe/age_range_signals/AgeRangeSignalsPlugin.kt
@@ -1,23 +1,31 @@
 package si.povhe.age_range_signals
 
+import android.app.Activity
 import android.content.Context
+import com.google.android.play.agesignals.AgeSignalsAccessRequest
+import com.google.android.play.agesignals.AgeSignalsAccessResult
 import com.google.android.play.agesignals.AgeSignalsManager
 import com.google.android.play.agesignals.AgeSignalsManagerFactory
 import com.google.android.play.agesignals.AgeSignalsRequest
 import com.google.android.play.agesignals.AgeSignalsException
 import com.google.android.play.agesignals.AgeSignalsResult
-import com.google.android.play.agesignals.model.AgeSignalsVerificationStatus
+import com.google.android.play.agesignals.model.AgeRangeSource
+import com.google.android.play.agesignals.model.AgeSignalsStatus
+import com.google.android.play.agesignals.model.SignificantChangeStatus
 import com.google.android.play.agesignals.testing.FakeAgeSignalsManager
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import java.util.Date
 
-class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler {
+class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
     private lateinit var context: Context
+    private var activity: Activity? = null
     private var ageSignalsManager: AgeSignalsManager? = null
     private var useFakeManager = false
     private var mockData: Map<String, Any?>? = null
@@ -40,6 +48,7 @@ class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler {
     private fun createFakeManager(): AgeSignalsManager {
         val fakeManager = FakeAgeSignalsManager()
         fakeManager.setNextAgeSignalsResult(buildMockResult(mockData))
+        fakeManager.setNextAgeSignalsAccessResult(buildMockAccessResult(mockData))
         return fakeManager
     }
 
@@ -47,6 +56,13 @@ class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler {
      * Builds the [AgeSignalsResult] returned by the fake manager from the optional
      * mock data map. Extracted from [createFakeManager] so the mapping logic is
      * unit-testable without the async Task layer.
+     *
+     * The mock `status` string is translated into the [AgeRangeSource] tier and
+     * [SignificantChangeStatus] pair that [resultToMap] derives that status back
+     * from, so mocked scenarios round-trip unchanged. Explicit `ageRangeSource` /
+     * `significantChangeStatus` entries win over the derived pair, for tests
+     * that target a specific tier (e.g. verified via tierD rather than the
+     * default tierC).
      *
      * IMPORTANT: Age ranges are determined by Google Play's parental control settings,
      * NOT by the app's configured age gates. Android ignores the ageGates parameter -
@@ -57,69 +73,109 @@ class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler {
         // custom mock data is supplied.
         val statusString = mockDataMap?.get("status") as? String ?: "supervised"
 
-        val userStatus = when (statusString) {
-            "verified" -> AgeSignalsVerificationStatus.VERIFIED
-            "supervised" -> AgeSignalsVerificationStatus.SUPERVISED
-            "supervisedApprovalPending" -> AgeSignalsVerificationStatus.SUPERVISED_APPROVAL_PENDING
-            "supervisedApprovalDenied" -> AgeSignalsVerificationStatus.SUPERVISED_APPROVAL_DENIED
-            "declared" -> AgeSignalsVerificationStatus.DECLARED
-            "unknown" -> AgeSignalsVerificationStatus.UNKNOWN
-            else -> AgeSignalsVerificationStatus.SUPERVISED
+        val derivedSource = when (statusString) {
+            "verified" -> AgeRangeSource.TIER_C
+            "declared" -> AgeRangeSource.TIER_A
+            "unknown" -> null
+            else -> AgeRangeSource.TIER_B
+        }
+        val derivedChangeStatus = when (statusString) {
+            "supervisedApprovalPending" -> SignificantChangeStatus.PENDING
+            "supervisedApprovalDenied" -> SignificantChangeStatus.DECLINED
+            else -> null
         }
 
-        val resultBuilder = AgeSignalsResult.builder().setUserStatus(userStatus)
+        val ageRangeSource =
+            ageRangeSourceFromName(mockDataMap?.get("ageRangeSource") as? String) ?: derivedSource
+        val changeStatus =
+            significantChangeStatusFromName(mockDataMap?.get("significantChangeStatus") as? String)
+                ?: derivedChangeStatus
 
-        // Age range only applies to supervised-like states (verified is 18+, no range).
-        if (userStatus == AgeSignalsVerificationStatus.SUPERVISED ||
-            userStatus == AgeSignalsVerificationStatus.SUPERVISED_APPROVAL_PENDING ||
-            userStatus == AgeSignalsVerificationStatus.SUPERVISED_APPROVAL_DENIED ||
-            userStatus == AgeSignalsVerificationStatus.DECLARED) {
+        val resultBuilder = AgeSignalsResult.builder()
+        ageRangeSource?.let { resultBuilder.setAgeRangeSource(it) }
+        changeStatus?.let { resultBuilder.setSignificantChangeStatus(it) }
+
+        // Explicit mock bounds apply to any tier: a real verified response
+        // carries the open-ended 18+ band. The 13-15 default is reserved for
+        // the declared and supervised tiers, where a band is always present,
+        // so verified mocks without explicit bounds keep their documented
+        // null bounds.
+        if (ageRangeSource != null) {
             val ageLowerRaw = mockDataMap?.get("ageLower") as? Int
-            resultBuilder.setAgeLower(ageLowerRaw ?: 13)
-
-            // Two cases produce a null ageUpper, distinguished by whether an explicit
-            // lower bound was given (the only signal that survives the Dart->map
-            // boundary, since toMap always includes the ageUpper key as null):
-            //  - explicit ageLower + omitted ageUpper -> open-ended top bucket
-            //    (e.g. ageLower=18, ageUpper=null), intentionally left unset
-            //  - no ageLower (no mock data at all, or a partial mock omitting both
-            //    bounds) -> apply the default supervised band (13-15)
             val ageUpperRaw = mockDataMap?.get("ageUpper") as? Int
-            if (ageUpperRaw != null) {
-                resultBuilder.setAgeUpper(ageUpperRaw)
-            } else if (ageLowerRaw == null) {
-                resultBuilder.setAgeUpper(15)
+            if (ageLowerRaw != null) {
+                resultBuilder.setAgeLower(ageLowerRaw)
+
+                // An explicit lower bound with an omitted upper bound is the
+                // intentional open-ended top bucket (e.g. ageLower=18,
+                // ageUpper=null); ageUpper stays unset.
+                if (ageUpperRaw != null) {
+                    resultBuilder.setAgeUpper(ageUpperRaw)
+                }
+            } else if (ageRangeSource == AgeRangeSource.TIER_A ||
+                ageRangeSource == AgeRangeSource.TIER_B
+            ) {
+                // No explicit lower bound (no mock data at all, or a partial
+                // mock omitting both bounds; toMap always serializes the keys,
+                // so both arrive as null): apply the default supervised band.
+                resultBuilder.setAgeLower(13)
+                resultBuilder.setAgeUpper(ageUpperRaw ?: 15)
             }
         }
 
-        // installId is set for supervised statuses, not for declared/verified.
-        if (userStatus == AgeSignalsVerificationStatus.SUPERVISED ||
-            userStatus == AgeSignalsVerificationStatus.SUPERVISED_APPROVAL_PENDING ||
-            userStatus == AgeSignalsVerificationStatus.SUPERVISED_APPROVAL_DENIED) {
+        // installId is set for supervised installs, not for declared/verified.
+        if (ageRangeSource == AgeRangeSource.TIER_B) {
             val installId = mockDataMap?.get("installId") as? String ?: "test_install_id_12345"
             resultBuilder.setInstallId(installId)
         }
 
-        (mockDataMap?.get("mostRecentApprovalDate") as? Number)?.let {
-            resultBuilder.setMostRecentApprovalDate(Date(it.toLong()))
+        (mockDataMap?.get("significantChangeApprovalDate") as? Number)?.let {
+            resultBuilder.setSignificantChangeApprovalDate(Date(it.toLong()))
         }
 
         return resultBuilder.build()
     }
 
     /**
+     * Builds the [AgeSignalsAccessResult] the fake manager answers
+     * requestAgeSignalsAccess with. Defaults to SHARED so mocked flows
+     * proceed straight into checkAgeSignals; notShared and
+     * verificationRequired exercise the gated paths.
+     */
+    internal fun buildMockAccessResult(mockDataMap: Map<String, Any?>?): AgeSignalsAccessResult {
+        val status = when (mockDataMap?.get("accessStatus") as? String) {
+            "notShared" -> AgeSignalsStatus.NOT_SHARED
+            "verificationRequired" -> AgeSignalsStatus.VERIFICATION_REQUIRED
+            // UNSPECIFIED maps back to "unknown", so the unrecognized-state
+            // fallback can be mocked like every other outcome.
+            "unknown" -> AgeSignalsStatus.UNSPECIFIED
+            else -> AgeSignalsStatus.SHARED
+        }
+        return AgeSignalsAccessResult.builder().setAgeSignalsStatus(status).build()
+    }
+
+    /**
      * Maps a platform [AgeSignalsResult] to the channel map consumed by Dart.
      * Shared by the real and fake manager listeners so the two paths cannot
      * drift apart. iOS-only keys are present but always null on Android.
+     *
+     * The library carries no user status of its own, so the cross-platform
+     * `status` is derived here: parent-managed accounts (tierB) surface the
+     * supervised family, refined by a pending or declined significant change;
+     * tierA is Play's self-declared flow; tierC/tierD are verified.
      */
     internal fun resultToMap(ageSignalsResult: AgeSignalsResult): Map<String, Any?> {
-        val status = when (ageSignalsResult.userStatus()) {
-            AgeSignalsVerificationStatus.VERIFIED -> "verified"
-            AgeSignalsVerificationStatus.SUPERVISED -> "supervised"
-            AgeSignalsVerificationStatus.SUPERVISED_APPROVAL_PENDING -> "supervisedApprovalPending"
-            AgeSignalsVerificationStatus.SUPERVISED_APPROVAL_DENIED -> "supervisedApprovalDenied"
-            AgeSignalsVerificationStatus.DECLARED -> "declared"
-            AgeSignalsVerificationStatus.UNKNOWN -> "unknown"
+        val ageRangeSource = ageSignalsResult.ageRangeSource()
+        val changeStatus = ageSignalsResult.significantChangeStatus()
+
+        val status = when (ageRangeSource) {
+            AgeRangeSource.TIER_A -> "declared"
+            AgeRangeSource.TIER_B -> when (changeStatus) {
+                SignificantChangeStatus.PENDING -> "supervisedApprovalPending"
+                SignificantChangeStatus.DECLINED -> "supervisedApprovalDenied"
+                else -> "supervised"
+            }
+            AgeRangeSource.TIER_C, AgeRangeSource.TIER_D -> "verified"
             else -> "unknown"
         }
 
@@ -128,10 +184,49 @@ class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler {
             "installId" to ageSignalsResult.installId(),
             "ageLower" to ageSignalsResult.ageLower(),
             "ageUpper" to ageSignalsResult.ageUpper(),
+            "ageRangeSource" to ageRangeSourceName(ageRangeSource),
+            "significantChangeStatus" to significantChangeStatusName(changeStatus),
             "source" to null,
             "activeParentalControls" to null,
-            "mostRecentApprovalDate" to ageSignalsResult.mostRecentApprovalDate()?.time
+            "significantChangeApprovalDate" to ageSignalsResult.significantChangeApprovalDate()?.time
         )
+    }
+
+    private fun ageRangeSourceFromName(name: String?): Int? = when (name) {
+        "tierA" -> AgeRangeSource.TIER_A
+        "tierB" -> AgeRangeSource.TIER_B
+        "tierC" -> AgeRangeSource.TIER_C
+        "tierD" -> AgeRangeSource.TIER_D
+        else -> null
+    }
+
+    private fun ageRangeSourceName(source: Int?): String? = when (source) {
+        AgeRangeSource.TIER_A -> "tierA"
+        AgeRangeSource.TIER_B -> "tierB"
+        AgeRangeSource.TIER_C -> "tierC"
+        AgeRangeSource.TIER_D -> "tierD"
+        else -> null
+    }
+
+    private fun significantChangeStatusFromName(name: String?): Int? = when (name) {
+        "approved" -> SignificantChangeStatus.APPROVED
+        "pending" -> SignificantChangeStatus.PENDING
+        "declined" -> SignificantChangeStatus.DECLINED
+        else -> null
+    }
+
+    private fun significantChangeStatusName(status: Int?): String? = when (status) {
+        SignificantChangeStatus.APPROVED -> "approved"
+        SignificantChangeStatus.PENDING -> "pending"
+        SignificantChangeStatus.DECLINED -> "declined"
+        else -> null
+    }
+
+    internal fun accessStatusName(status: Int?): String = when (status) {
+        AgeSignalsStatus.SHARED -> "shared"
+        AgeSignalsStatus.NOT_SHARED -> "notShared"
+        AgeSignalsStatus.VERIFICATION_REQUIRED -> "verificationRequired"
+        else -> "unknown"
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
@@ -142,6 +237,9 @@ class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler {
                 // Store mock data for use when creating fake manager
                 mockData = call.argument<Map<String, Any?>>("mockData")
                 result.success(null)
+            }
+            "requestAgeSignalsAccess" -> {
+                requestAgeSignalsAccess(result)
             }
             "checkAgeSignals" -> {
                 checkAgeSignals(result)
@@ -163,6 +261,46 @@ class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler {
                 result.notImplemented()
             }
         }
+    }
+
+    private fun requestAgeSignalsAccess(result: Result) {
+        // Play renders the age sharing prompt over the current activity, so
+        // the request cannot be built from the application context alone.
+        val activity = this.activity
+        if (activity == null) {
+            result.error(
+                "PRESENTATION_CONTEXT_UNAVAILABLE",
+                "No foreground activity to present the age sharing prompt on",
+                null
+            )
+            return
+        }
+
+        // Like checkAgeSignals, an explicit mock request runs against the
+        // fake manager even when the real API is unavailable.
+        val manager = if (useFakeManager) createFakeManager() else ageSignalsManager
+        if (manager == null) {
+            result.error(
+                "API_NOT_AVAILABLE",
+                "Age Signals API is not available on this device",
+                null
+            )
+            return
+        }
+
+        val request = AgeSignalsAccessRequest.builder().setActivity(activity).build()
+
+        manager.requestAgeSignalsAccess(request)
+            .addOnSuccessListener { accessResult ->
+                result.success(accessStatusName(accessResult.ageSignalsStatus()))
+            }
+            .addOnFailureListener { exception ->
+                result.error(
+                    channelErrorCode(exception),
+                    exception.message ?: "An error occurred while requesting age signals access",
+                    "Exception type: ${exception.javaClass.simpleName}"
+                )
+            }
     }
 
     private fun checkAgeSignals(result: Result) {
@@ -205,35 +343,55 @@ class AgeRangeSignalsPlugin : FlutterPlugin, MethodCallHandler {
                 result.success(resultToMap(ageSignalsResult))
             }
             .addOnFailureListener { exception ->
-                val errorMessage = exception.message ?: "An error occurred while checking age signals"
-                val errorCode = if (exception is AgeSignalsException) {
-                    when (exception.errorCode) {
-                        -1 -> "API_NOT_AVAILABLE"
-                        -2 -> "PLAY_SERVICES_ERROR"
-                        -3 -> "NETWORK_ERROR"
-                        -4 -> "PLAY_SERVICES_ERROR"
-                        -5 -> "PLAY_SERVICES_ERROR"
-                        -6 -> "PLAY_SERVICES_ERROR"
-                        -7 -> "PLAY_SERVICES_ERROR"
-                        -8 -> "API_ERROR"
-                        -9 -> "API_NOT_AVAILABLE"
-                        -10 -> "SDK_VERSION_OUTDATED"
-                        -100 -> "API_ERROR"
-                        else -> "API_ERROR"
-                    }
-                } else {
-                    "API_ERROR"
-                }
-
                 result.error(
-                    errorCode,
-                    errorMessage,
+                    channelErrorCode(exception),
+                    exception.message ?: "An error occurred while checking age signals",
                     "Exception type: ${exception.javaClass.simpleName}"
                 )
             }
     }
 
+    /**
+     * Maps a Play library failure onto the channel's error codes; the numeric
+     * values are the library's AgeSignalsErrorCode constants. A declined
+     * sharing prompt is not a failure - it arrives as a notShared access
+     * result, never through this path.
+     */
+    private fun channelErrorCode(exception: Exception): String {
+        if (exception !is AgeSignalsException) return "API_ERROR"
+        return when (exception.errorCode) {
+            -1 -> "API_NOT_AVAILABLE"
+            -2 -> "PLAY_SERVICES_ERROR"
+            -3 -> "NETWORK_ERROR"
+            -4 -> "PLAY_SERVICES_ERROR"
+            -5 -> "PLAY_SERVICES_ERROR"
+            -6 -> "PLAY_SERVICES_ERROR"
+            -7 -> "PLAY_SERVICES_ERROR"
+            -8 -> "API_ERROR"
+            -9 -> "API_NOT_AVAILABLE"
+            -10 -> "SDK_VERSION_OUTDATED"
+            -100 -> "API_ERROR"
+            else -> "API_ERROR"
+        }
+    }
+
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+    }
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activity = binding.activity
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        activity = null
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        activity = binding.activity
+    }
+
+    override fun onDetachedFromActivity() {
+        activity = null
     }
 }

--- a/android/src/test/kotlin/si/povhe/age_range_signals/AgeRangeSignalsPluginTest.kt
+++ b/android/src/test/kotlin/si/povhe/age_range_signals/AgeRangeSignalsPluginTest.kt
@@ -1,6 +1,10 @@
 package si.povhe.age_range_signals
 
-import com.google.android.play.agesignals.model.AgeSignalsVerificationStatus
+import android.app.Activity
+import com.google.android.play.agesignals.model.AgeRangeSource
+import com.google.android.play.agesignals.model.AgeSignalsStatus
+import com.google.android.play.agesignals.model.SignificantChangeStatus
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import org.mockito.Mockito
@@ -26,7 +30,7 @@ internal class AgeRangeSignalsPluginTest {
     fun buildMockResult_noMockData_usesDefaultSupervised13to15() {
         val result = AgeRangeSignalsPlugin().buildMockResult(null)
 
-        assertEquals(AgeSignalsVerificationStatus.SUPERVISED, result.userStatus())
+        assertEquals(AgeRangeSource.TIER_B, result.ageRangeSource())
         assertEquals(13, result.ageLower())
         assertEquals(15, result.ageUpper())
     }
@@ -70,8 +74,155 @@ internal class AgeRangeSignalsPluginTest {
     fun buildMockResult_verified_hasNoAgeRange() {
         val result = AgeRangeSignalsPlugin().buildMockResult(mapOf("status" to "verified"))
 
-        assertEquals(AgeSignalsVerificationStatus.VERIFIED, result.userStatus())
+        assertEquals(AgeRangeSource.TIER_C, result.ageRangeSource())
         assertNull(result.ageLower())
         assertNull(result.ageUpper())
+    }
+
+    @Test
+    fun buildMockResult_verifiedWithExplicitLower_reportsOpenEnded18Plus() {
+        // A real verified response carries the open-ended 18+ band; explicit
+        // bounds apply to verified mocks, only the 13-15 default is
+        // supervised/declared-specific.
+        val result = AgeRangeSignalsPlugin().buildMockResult(
+            mapOf("status" to "verified", "ageLower" to 18),
+        )
+
+        assertEquals(18, result.ageLower())
+        assertNull(result.ageUpper())
+    }
+
+    // --- Status to tier/change-status derivation ---
+
+    @Test
+    fun buildMockResult_pendingStatus_derivesTierBWithPendingChange() {
+        val result = AgeRangeSignalsPlugin().buildMockResult(
+            mapOf("status" to "supervisedApprovalPending"),
+        )
+
+        assertEquals(AgeRangeSource.TIER_B, result.ageRangeSource())
+        assertEquals(SignificantChangeStatus.PENDING, result.significantChangeStatus())
+    }
+
+    @Test
+    fun buildMockResult_deniedStatus_derivesTierBWithDeclinedChange() {
+        val result = AgeRangeSignalsPlugin().buildMockResult(
+            mapOf("status" to "supervisedApprovalDenied"),
+        )
+
+        assertEquals(AgeRangeSource.TIER_B, result.ageRangeSource())
+        assertEquals(SignificantChangeStatus.DECLINED, result.significantChangeStatus())
+    }
+
+    @Test
+    fun buildMockResult_declaredStatus_derivesTierA() {
+        val result = AgeRangeSignalsPlugin().buildMockResult(mapOf("status" to "declared"))
+
+        assertEquals(AgeRangeSource.TIER_A, result.ageRangeSource())
+        // Self-declared users have an age band but no install id.
+        assertEquals(13, result.ageLower())
+        assertNull(result.installId())
+    }
+
+    @Test
+    fun buildMockResult_unknownStatus_leavesSignalsUnset() {
+        val result = AgeRangeSignalsPlugin().buildMockResult(mapOf("status" to "unknown"))
+
+        assertNull(result.ageRangeSource())
+        assertNull(result.significantChangeStatus())
+        assertNull(result.ageLower())
+        assertNull(result.installId())
+    }
+
+    @Test
+    fun buildMockResult_explicitTier_winsOverStatus() {
+        // A mock pinning the tier is authoritative; the status shorthand only
+        // fills in what was not stated explicitly.
+        val result = AgeRangeSignalsPlugin().buildMockResult(
+            mapOf("status" to "verified", "ageRangeSource" to "tierD"),
+        )
+
+        assertEquals(AgeRangeSource.TIER_D, result.ageRangeSource())
+    }
+
+    @Test
+    fun buildMockResult_explicitChangeStatus_isHonored() {
+        val result = AgeRangeSignalsPlugin().buildMockResult(
+            mapOf("status" to "supervised", "significantChangeStatus" to "approved"),
+        )
+
+        assertEquals(AgeRangeSource.TIER_B, result.ageRangeSource())
+        assertEquals(SignificantChangeStatus.APPROVED, result.significantChangeStatus())
+    }
+
+    // --- Access request mocking (new in 0.0.4) ---
+
+    @Test
+    fun buildMockAccessResult_defaultsToShared() {
+        val result = AgeRangeSignalsPlugin().buildMockAccessResult(null)
+
+        assertEquals(AgeSignalsStatus.SHARED, result.ageSignalsStatus())
+    }
+
+    @Test
+    fun buildMockAccessResult_explicitStatus_isHonored() {
+        val plugin = AgeRangeSignalsPlugin()
+
+        val notShared = plugin.buildMockAccessResult(mapOf("accessStatus" to "notShared"))
+        assertEquals(AgeSignalsStatus.NOT_SHARED, notShared.ageSignalsStatus())
+
+        val verification =
+            plugin.buildMockAccessResult(mapOf("accessStatus" to "verificationRequired"))
+        assertEquals(AgeSignalsStatus.VERIFICATION_REQUIRED, verification.ageSignalsStatus())
+
+        // "unknown" round-trips through UNSPECIFIED rather than falling into
+        // the shared default.
+        val unknown = plugin.buildMockAccessResult(mapOf("accessStatus" to "unknown"))
+        assertEquals(AgeSignalsStatus.UNSPECIFIED, unknown.ageSignalsStatus())
+    }
+
+    @Test
+    fun requestAgeSignalsAccess_withoutActivity_reportsPresentationContextUnavailable() {
+        val plugin = AgeRangeSignalsPlugin()
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+
+        plugin.onMethodCall(MethodCall("requestAgeSignalsAccess", null), mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("PRESENTATION_CONTEXT_UNAVAILABLE"),
+            Mockito.anyString(),
+            Mockito.isNull(),
+        )
+    }
+
+    @Test
+    fun requestAgeSignalsAccess_withActivityButNoManager_reportsApiNotAvailable() {
+        val plugin = AgeRangeSignalsPlugin()
+        val binding = Mockito.mock(ActivityPluginBinding::class.java)
+        Mockito.`when`(binding.activity).thenReturn(Mockito.mock(Activity::class.java))
+        plugin.onAttachedToActivity(binding)
+
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(MethodCall("requestAgeSignalsAccess", null), mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("API_NOT_AVAILABLE"),
+            Mockito.anyString(),
+            Mockito.isNull(),
+        )
+    }
+
+    @Test
+    fun accessStatusName_mapsEveryKnownValueAndFallsBackToUnknown() {
+        val plugin = AgeRangeSignalsPlugin()
+
+        assertEquals("shared", plugin.accessStatusName(AgeSignalsStatus.SHARED))
+        assertEquals("notShared", plugin.accessStatusName(AgeSignalsStatus.NOT_SHARED))
+        assertEquals(
+            "verificationRequired",
+            plugin.accessStatusName(AgeSignalsStatus.VERIFICATION_REQUIRED),
+        )
+        assertEquals("unknown", plugin.accessStatusName(AgeSignalsStatus.UNSPECIFIED))
+        assertEquals("unknown", plugin.accessStatusName(null))
     }
 }

--- a/android/src/test/kotlin/si/povhe/age_range_signals/ResultMapTest.kt
+++ b/android/src/test/kotlin/si/povhe/age_range_signals/ResultMapTest.kt
@@ -15,13 +15,13 @@ class ResultMapTest {
                 "ageLower" to 13,
                 "ageUpper" to 15,
                 "installId" to "test_id",
-                "mostRecentApprovalDate" to 1735689600000L,
+                "significantChangeApprovalDate" to 1735689600000L,
             )
         )
         val map = plugin.resultToMap(result)
 
         assertEquals("supervised", map["status"])
-        assertEquals(1735689600000L, map["mostRecentApprovalDate"])
+        assertEquals(1735689600000L, map["significantChangeApprovalDate"])
         // iOS-only key must exist and be null so the Dart map shape is stable
         assertNull(map["activeParentalControls"])
     }
@@ -32,6 +32,73 @@ class ResultMapTest {
         val map = plugin.resultToMap(result)
 
         assertEquals("verified", map["status"])
-        assertNull(map["mostRecentApprovalDate"])
+        assertNull(map["significantChangeApprovalDate"])
+    }
+
+    // --- Status derivation from ageRangeSource + significantChangeStatus ---
+
+    @Test
+    fun resultToMap_statusRoundTripsForEveryMockStatus() {
+        // buildMockResult translates a status into the tier/change-status pair
+        // and resultToMap derives it back; the two mappings must stay inverse
+        // or mocked scenarios silently shift meaning.
+        val statuses = listOf(
+            "supervised",
+            "supervisedApprovalPending",
+            "supervisedApprovalDenied",
+            "verified",
+            "declared",
+            "unknown",
+        )
+        for (status in statuses) {
+            val map = plugin.resultToMap(plugin.buildMockResult(mapOf("status" to status)))
+            assertEquals(status, map["status"])
+        }
+    }
+
+    @Test
+    fun resultToMap_exposesTierAndChangeStatus() {
+        val map = plugin.resultToMap(
+            plugin.buildMockResult(mapOf("status" to "supervisedApprovalPending")),
+        )
+
+        assertEquals("supervisedApprovalPending", map["status"])
+        assertEquals("tierB", map["ageRangeSource"])
+        assertEquals("pending", map["significantChangeStatus"])
+    }
+
+    @Test
+    fun resultToMap_tierBApproved_reportsSupervisedWithApprovedChange() {
+        // APPROVED must not shift the status: only pending/declined refine the
+        // supervised family.
+        val map = plugin.resultToMap(
+            plugin.buildMockResult(
+                mapOf("status" to "supervised", "significantChangeStatus" to "approved"),
+            ),
+        )
+
+        assertEquals("supervised", map["status"])
+        assertEquals("tierB", map["ageRangeSource"])
+        assertEquals("approved", map["significantChangeStatus"])
+    }
+
+    @Test
+    fun resultToMap_tierDVerified_reportsVerifiedWithExplicitTier() {
+        val result = plugin.buildMockResult(
+            mapOf("status" to "verified", "ageRangeSource" to "tierD"),
+        )
+        val map = plugin.resultToMap(result)
+
+        assertEquals("verified", map["status"])
+        assertEquals("tierD", map["ageRangeSource"])
+    }
+
+    @Test
+    fun resultToMap_unknown_hasNullTierAndChangeStatus() {
+        val map = plugin.resultToMap(plugin.buildMockResult(mapOf("status" to "unknown")))
+
+        assertEquals("unknown", map["status"])
+        assertNull(map["ageRangeSource"])
+        assertNull(map["significantChangeStatus"])
     }
 }

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -16,6 +16,36 @@ void main() {
     );
   });
 
+  testWidgets('requestAgeSignalsAccess resolves to a typed outcome', (
+    WidgetTester tester,
+  ) async {
+    // A MissingPluginException here would mean the channel method name is
+    // wired wrong on one platform.
+    try {
+      final status = await AgeRangeSignals.instance
+          .requestAgeSignalsAccess()
+          .timeout(const Duration(seconds: 20));
+      expect(status, isA<AgeSignalsAccessStatus>());
+      if (Platform.isIOS) {
+        // iOS has no separate access grant; shared is the fixed answer.
+        expect(status, AgeSignalsAccessStatus.shared);
+      }
+    } on AgeSignalsException catch (e) {
+      // Acceptable on Android builds without Play (emulator, sideload).
+      // ignore: avoid_print
+      print('requestAgeSignalsAccess threw: ${e.runtimeType}: $e');
+    } on TimeoutException {
+      // Play presented its age sharing prompt and is waiting for a person;
+      // integration tests cannot tap system UI. Reaching the prompt still
+      // proves the native call went through.
+      // ignore: avoid_print
+      print(
+        'requestAgeSignalsAccess: prompt presented (timed out waiting for '
+        'user input, as expected in an automated run)',
+      );
+    }
+  });
+
   testWidgets('checkAgeSignals returns a result or throws exception', (
     WidgetTester tester,
   ) async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,7 @@ class _AgeSignalsDemoState extends State<AgeSignalsDemo> {
   bool _isInitialized = false;
   final bool _isIos = Platform.isIOS;
   String _currentScenario = 'Default (Supervised 13-15)';
+  String? _accessOutcome;
   String? _regulatoryOutcome;
   String? _acknowledgmentOutcome;
 
@@ -73,8 +74,25 @@ class _AgeSignalsDemoState extends State<AgeSignalsDemo> {
       _currentScenario = scenarioName;
       _result = null;
       _error = null;
+      _accessOutcome = null;
     });
     await _initializePlugin(mockData: mockData);
+  }
+
+  Future<void> _requestAccess() async {
+    setState(() {
+      _accessOutcome = 'Requesting...';
+    });
+    try {
+      final status = await AgeRangeSignals.instance.requestAgeSignalsAccess();
+      setState(() {
+        _accessOutcome = _getAccessStatusText(status);
+      });
+    } on AgeSignalsException catch (e) {
+      setState(() {
+        _accessOutcome = '${e.runtimeType}: ${e.message}';
+      });
+    }
   }
 
   Future<void> _checkAgeSignals() async {
@@ -181,6 +199,8 @@ class _AgeSignalsDemoState extends State<AgeSignalsDemo> {
             if (_isIos) ...[const SizedBox(height: 12), _buildIosWarningCard()],
             if (!_isIos) ...[const SizedBox(height: 12), _buildScenarioCard()],
             const SizedBox(height: 16),
+            _buildAccessButton(),
+            const SizedBox(height: 12),
             _buildCheckButton(),
             const SizedBox(height: 12),
             _buildRegulatoryCard(),
@@ -315,6 +335,13 @@ class _AgeSignalsDemoState extends State<AgeSignalsDemo> {
                   'Unknown',
                   const AgeSignalsMockData(status: AgeSignalsStatus.unknown),
                 ),
+                _buildScenarioChip(
+                  'Access Not Shared',
+                  const AgeSignalsMockData(
+                    status: AgeSignalsStatus.unknown,
+                    accessStatus: AgeSignalsAccessStatus.notShared,
+                  ),
+                ),
               ],
             ),
           ],
@@ -327,6 +354,32 @@ class _AgeSignalsDemoState extends State<AgeSignalsDemo> {
     return ActionChip(
       label: Text(label),
       onPressed: () => _reinitializeWithScenario(label, mockData),
+    );
+  }
+
+  Widget _buildAccessButton() {
+    // Step 1 of the Play flow: ask for access (may show Play's age sharing
+    // prompt). On iOS this resolves to "shared" without showing anything.
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        OutlinedButton.icon(
+          onPressed: _isLoading || !_isInitialized ? null : _requestAccess,
+          icon: const Icon(Icons.lock_open),
+          label: const Text('Request Age Signals Access'),
+          style: OutlinedButton.styleFrom(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+          ),
+        ),
+        if (_accessOutcome != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            'Access: $_accessOutcome',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ],
     );
   }
 
@@ -488,6 +541,21 @@ class _AgeSignalsDemoState extends State<AgeSignalsDemo> {
               _buildResultRow('Age Upper Bound', _result!.ageUpper.toString()),
             if (_result!.source != null)
               _buildResultRow('Source', _getSourceText(_result!.source!)),
+            if (_result!.ageRangeSource != null)
+              _buildResultRow(
+                'Range Source',
+                _getAgeRangeSourceText(_result!.ageRangeSource!),
+              ),
+            if (_result!.significantChangeStatus != null)
+              _buildResultRow(
+                'Change Status',
+                _getChangeStatusText(_result!.significantChangeStatus!),
+              ),
+            if (_result!.significantChangeApprovalDate != null)
+              _buildResultRow(
+                'Change Approved',
+                _result!.significantChangeApprovalDate!.toIso8601String(),
+              ),
             if (_result!.installId != null)
               _buildResultRow('Install ID', _result!.installId!),
           ],
@@ -540,6 +608,43 @@ class _AgeSignalsDemoState extends State<AgeSignalsDemo> {
         return 'Self Declared';
       case AgeDeclarationSource.guardianDeclared:
         return 'Guardian Declared';
+    }
+  }
+
+  String _getAccessStatusText(AgeSignalsAccessStatus status) {
+    switch (status) {
+      case AgeSignalsAccessStatus.shared:
+        return 'Shared (age signals available)';
+      case AgeSignalsAccessStatus.notShared:
+        return 'Not shared (user or parent declined)';
+      case AgeSignalsAccessStatus.verificationRequired:
+        return 'Verification required (completed in the Play Store)';
+      case AgeSignalsAccessStatus.unknown:
+        return 'Unknown';
+    }
+  }
+
+  String _getAgeRangeSourceText(AgeRangeSource source) {
+    switch (source) {
+      case AgeRangeSource.tierA:
+        return 'Tier A (self-declared)';
+      case AgeRangeSource.tierB:
+        return 'Tier B (parent-managed account)';
+      case AgeRangeSource.tierC:
+        return 'Tier C (verified)';
+      case AgeRangeSource.tierD:
+        return 'Tier D (strongly verified)';
+    }
+  }
+
+  String _getChangeStatusText(SignificantChangeStatus status) {
+    switch (status) {
+      case SignificantChangeStatus.approved:
+        return 'Approved (parent approved the latest change)';
+      case SignificantChangeStatus.pending:
+        return 'Pending (waiting for parent approval)';
+      case SignificantChangeStatus.declined:
+        return 'Declined (parent denied the change)';
     }
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.8.0"
   async:
     dependency: transitive
     description:

--- a/ios/age_range_signals.podspec
+++ b/ios/age_range_signals.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'age_range_signals'
-  s.version          = '0.7.0'
+  s.version          = '0.8.0'
   s.summary          = 'Flutter plugin for age verification.'
   s.description      = <<-DESC
 Flutter plugin for age verification supporting Google Play Age Signals API (Android) and Apple's DeclaredAgeRange API (iOS 26+).

--- a/ios/age_range_signals/Classes/AgeRangeSignalsPlugin.swift
+++ b/ios/age_range_signals/Classes/AgeRangeSignalsPlugin.swift
@@ -22,6 +22,13 @@ public class AgeRangeSignalsPlugin: NSObject, FlutterPlugin {
         switch call.method {
         case "initialize":
             handleInitialize(call: call, result: result)
+        case "requestAgeSignalsAccess":
+            // Play's separate access grant has no Apple counterpart: consent
+            // is gathered by requestAgeRange() inside checkAgeSignals, and a
+            // refusal surfaces there as the "declined" status. "shared" is
+            // the honest answer and keeps one call sequence working on both
+            // platforms.
+            result("shared")
         case "checkAgeSignals":
             handleCheckAgeSignals(result: result)
         case "getRequiredRegulatoryFeatures":
@@ -249,7 +256,9 @@ public class AgeRangeSignalsPlugin: NSObject, FlutterPlugin {
             "source": source as Any? ?? NSNull(),
             "installId": NSNull(),
             "activeParentalControls": activeParentalControls as Any? ?? NSNull(),
-            "mostRecentApprovalDate": NSNull()
+            "ageRangeSource": NSNull(),
+            "significantChangeStatus": NSNull(),
+            "significantChangeApprovalDate": NSNull()
         ]
     }
 

--- a/lib/age_range_signals.dart
+++ b/lib/age_range_signals.dart
@@ -8,10 +8,12 @@ library;
 import 'age_range_signals_platform_interface.dart';
 import 'src/exceptions/age_signals_exception.dart';
 import 'src/models/age_regulatory_feature.dart';
+import 'src/models/age_signals_access_status.dart';
 import 'src/models/age_signals_result.dart';
 import 'src/models/age_signals_mock_data.dart';
 
 export 'src/models/age_signals_result.dart';
+export 'src/models/age_signals_access_status.dart';
 export 'src/models/age_signals_mock_data.dart';
 export 'src/exceptions/age_signals_exception.dart';
 export 'src/models/age_regulatory_feature.dart';
@@ -26,8 +28,14 @@ export 'src/models/age_regulatory_feature.dart';
 /// // Initialize with age gates (iOS only, optional on Android)
 /// await AgeRangeSignals.instance.initialize(ageGates: [13, 16, 18]);
 ///
-/// // Check age signals
+/// // Request access, then check age signals
 /// try {
+///   final access = await AgeRangeSignals.instance.requestAgeSignalsAccess();
+///   if (access != AgeSignalsAccessStatus.shared) {
+///     print('No age signals to read: $access');
+///     return;
+///   }
+///
 ///   final result = await AgeRangeSignals.instance.checkAgeSignals();
 ///
 ///   switch (result.status) {
@@ -107,10 +115,50 @@ class AgeRangeSignals {
     );
   }
 
+  /// Requests access to the current user's age signals (Android).
+  ///
+  /// Since age-signals 0.0.4, Google Play splits age signals across two
+  /// calls: this one asks for access - showing Play's in-app age sharing
+  /// prompt when the user's Play settings call for asking first - and
+  /// [checkAgeSignals] then reads the signals. Call this before
+  /// [checkAgeSignals] and only read signals once access is
+  /// [AgeSignalsAccessStatus.shared]:
+  ///
+  /// ```dart
+  /// final access = await AgeRangeSignals.instance.requestAgeSignalsAccess();
+  /// if (access == AgeSignalsAccessStatus.shared) {
+  ///   final result = await AgeRangeSignals.instance.checkAgeSignals();
+  /// }
+  /// ```
+  ///
+  /// A refusal is not an error: it returns
+  /// [AgeSignalsAccessStatus.notShared]. In regions with mandatory
+  /// verification laws Play skips the prompt entirely: already-verified and
+  /// supervised users come back [AgeSignalsAccessStatus.shared], while
+  /// unverified users come back
+  /// [AgeSignalsAccessStatus.verificationRequired] and complete
+  /// verification in the Play Store app before signals become available.
+  ///
+  /// On iOS this returns [AgeSignalsAccessStatus.shared] without showing
+  /// anything: Apple gathers consent inside [checkAgeSignals] itself, and a
+  /// refusal surfaces there as [AgeSignalsStatus.declined]. Returning
+  /// shared keeps a single call sequence working on both platforms.
+  ///
+  /// Throws [AgeSignalsException] subclasses on API errors, including
+  /// [ApiErrorException] with code `PRESENTATION_CONTEXT_UNAVAILABLE` when
+  /// no activity is available to present the prompt on (Android).
+  Future<AgeSignalsAccessStatus> requestAgeSignalsAccess() {
+    return AgeRangeSignalsPlatform.instance.requestAgeSignalsAccess();
+  }
+
   /// Checks the age signals for the current user.
   ///
   /// Returns an [AgeSignalsResult] containing the verification status and
   /// any available age information.
+  ///
+  /// On Android, call [requestAgeSignalsAccess] first; without shared
+  /// access the Play Age Signals API returns no signals and the status is
+  /// [AgeSignalsStatus.unknown].
   ///
   /// On iOS, you must call [initialize] with age gates before calling this method.
   ///

--- a/lib/age_range_signals_method_channel.dart
+++ b/lib/age_range_signals_method_channel.dart
@@ -13,6 +13,7 @@ import 'package:flutter/services.dart';
 import 'age_range_signals_platform_interface.dart';
 import 'src/exceptions/age_signals_exception.dart';
 import 'src/models/age_regulatory_feature.dart';
+import 'src/models/age_signals_access_status.dart';
 import 'src/models/age_signals_mock_data.dart';
 import 'src/models/age_signals_result.dart';
 
@@ -41,6 +42,21 @@ class MethodChannelAgeRangeSignals extends AgeRangeSignalsPlatform {
         'useMockData': useMockData,
         'mockData': mockData?.toMap(),
       });
+    } on PlatformException catch (e) {
+      throw _handlePlatformException(e);
+    }
+  }
+
+  @override
+  Future<AgeSignalsAccessStatus> requestAgeSignalsAccess() async {
+    try {
+      final status = await methodChannel.invokeMethod<String>(
+        'requestAgeSignalsAccess',
+      );
+      if (status == null) {
+        throw const AgeSignalsException('Received null result from platform');
+      }
+      return AgeSignalsAccessStatus.fromName(status);
     } on PlatformException catch (e) {
       throw _handlePlatformException(e);
     }
@@ -115,7 +131,8 @@ class MethodChannelAgeRangeSignals extends AgeRangeSignalsPlatform {
         );
       case 'PRESENTATION_CONTEXT_UNAVAILABLE':
         return ApiErrorException(
-          e.message ?? 'No view controller or window scene available',
+          e.message ??
+              'No view controller, window scene, or activity available',
           e.code,
           details,
         );

--- a/lib/age_range_signals_platform_interface.dart
+++ b/lib/age_range_signals_platform_interface.dart
@@ -11,6 +11,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'age_range_signals_method_channel.dart';
 import 'src/exceptions/age_signals_exception.dart';
 import 'src/models/age_regulatory_feature.dart';
+import 'src/models/age_signals_access_status.dart';
 import 'src/models/age_signals_result.dart';
 import 'src/models/age_signals_mock_data.dart';
 
@@ -61,6 +62,19 @@ abstract class AgeRangeSignalsPlatform extends PlatformInterface {
     AgeSignalsMockData? mockData,
   }) {
     throw UnimplementedError('initialize() has not been implemented.');
+  }
+
+  /// Requests access to the current user's age signals (Android).
+  ///
+  /// May show Google Play's in-app age sharing prompt. Returns
+  /// [AgeSignalsAccessStatus.shared] on iOS, where consent is gathered by
+  /// [checkAgeSignals] itself.
+  ///
+  /// Throws [AgeSignalsException] if an error occurs during the request.
+  Future<AgeSignalsAccessStatus> requestAgeSignalsAccess() {
+    throw UnimplementedError(
+      'requestAgeSignalsAccess() has not been implemented.',
+    );
   }
 
   /// Checks the age signals for the current user.

--- a/lib/src/models/age_signals_access_status.dart
+++ b/lib/src/models/age_signals_access_status.dart
@@ -1,0 +1,42 @@
+/// Outcome of requesting access to the user's age signals.
+///
+/// Returned by `AgeRangeSignals.instance.requestAgeSignalsAccess()`. Since
+/// age-signals 0.0.4 Google Play splits age signals across two calls: the
+/// access request (which may show Play's in-app age sharing prompt) and
+/// `checkAgeSignals()`, which only carries signals once access is [shared].
+enum AgeSignalsAccessStatus {
+  /// Age signals are shared; proceed to `checkAgeSignals()`.
+  ///
+  /// Play reports this when the user or their parent agreed to share, or in
+  /// regions where sharing is automatic. Always returned on iOS, where
+  /// consent is gathered inside `checkAgeSignals()` itself and a refusal
+  /// surfaces there as `AgeSignalsStatus.declined`.
+  shared,
+
+  /// The user is not sharing age signals.
+  ///
+  /// The user declined the prompt or previously chose not to share, a
+  /// parent rejected sharing, or the user is not eligible. A decline is a
+  /// normal outcome, not an error; `checkAgeSignals()` carries no signals
+  /// in this state.
+  notShared,
+
+  /// The user must verify their age in the Play Store first.
+  ///
+  /// Reported in regions with mandatory verification laws when the age is
+  /// unknown. Play does not show the in-app prompt here; the user completes
+  /// verification in the Play Store app.
+  verificationRequired,
+
+  /// Play reported a state this plugin version does not recognize.
+  unknown;
+
+  /// Parses a status name coming over the platform channel.
+  ///
+  /// Falls back to [unknown] for names this version does not know, so
+  /// future Google additions degrade gracefully instead of crashing the
+  /// parse.
+  static AgeSignalsAccessStatus fromName(String name) =>
+      AgeSignalsAccessStatus.values.asNameMap()[name] ??
+      AgeSignalsAccessStatus.unknown;
+}

--- a/lib/src/models/age_signals_mock_data.dart
+++ b/lib/src/models/age_signals_mock_data.dart
@@ -1,3 +1,4 @@
+import 'age_signals_access_status.dart';
 import 'age_signals_result.dart';
 
 /// Configuration for mock/test data used when [useMockData] is true.
@@ -29,7 +30,10 @@ class AgeSignalsMockData {
     this.ageUpper,
     this.source,
     this.installId,
-    this.mostRecentApprovalDate,
+    this.accessStatus,
+    this.ageRangeSource,
+    this.significantChangeStatus,
+    this.significantChangeApprovalDate,
   });
 
   /// The mock verification status to return.
@@ -57,11 +61,37 @@ class AgeSignalsMockData {
   /// Only used when testing Android scenarios.
   final String? installId;
 
-  /// Mock guardian approval date (Android only).
+  /// The mock outcome of `requestAgeSignalsAccess()` (Android only).
   ///
-  /// Maps to the `mostRecentApprovalDate` reported by the Play Age Signals
-  /// API for supervised users.
-  final DateTime? mostRecentApprovalDate;
+  /// Defaults to [AgeSignalsAccessStatus.shared] when null, so mocked
+  /// flows proceed straight into `checkAgeSignals()`. Set
+  /// [AgeSignalsAccessStatus.notShared] or
+  /// [AgeSignalsAccessStatus.verificationRequired] to exercise the paths
+  /// where no age signals may be requested.
+  final AgeSignalsAccessStatus? accessStatus;
+
+  /// Explicit mock [AgeRangeSource] tier (Android only).
+  ///
+  /// When null, the tier is derived from [status] (verified maps to tierC,
+  /// declared to tierA, the supervised family to tierB). The result's
+  /// status is always re-derived from the resolved tier and change status,
+  /// exactly as with real API responses, so an explicit tier wins over a
+  /// contradictory [status]. Set it to pin a specific tier, e.g. verified
+  /// via [AgeRangeSource.tierD].
+  final AgeRangeSource? ageRangeSource;
+
+  /// Explicit mock [SignificantChangeStatus] (Android only).
+  ///
+  /// When null, it is derived from [status]
+  /// (supervisedApprovalPending maps to pending, supervisedApprovalDenied
+  /// to declined, otherwise unset).
+  final SignificantChangeStatus? significantChangeStatus;
+
+  /// Mock significant change approval date (Android only).
+  ///
+  /// Maps to the `significantChangeApprovalDate` reported by the Play Age
+  /// Signals API for supervised users.
+  final DateTime? significantChangeApprovalDate;
 
   /// Converts this mock data to a map for platform channel.
   Map<String, dynamic> toMap() {
@@ -71,7 +101,11 @@ class AgeSignalsMockData {
       'ageUpper': ageUpper,
       'source': source?.name,
       'installId': installId,
-      'mostRecentApprovalDate': mostRecentApprovalDate?.millisecondsSinceEpoch,
+      'accessStatus': accessStatus?.name,
+      'ageRangeSource': ageRangeSource?.name,
+      'significantChangeStatus': significantChangeStatus?.name,
+      'significantChangeApprovalDate':
+          significantChangeApprovalDate?.millisecondsSinceEpoch,
     };
   }
 
@@ -82,7 +116,10 @@ class AgeSignalsMockData {
     int? ageUpper,
     AgeDeclarationSource? source,
     String? installId,
-    DateTime? mostRecentApprovalDate,
+    AgeSignalsAccessStatus? accessStatus,
+    AgeRangeSource? ageRangeSource,
+    SignificantChangeStatus? significantChangeStatus,
+    DateTime? significantChangeApprovalDate,
   }) {
     return AgeSignalsMockData(
       status: status ?? this.status,
@@ -90,8 +127,12 @@ class AgeSignalsMockData {
       ageUpper: ageUpper ?? this.ageUpper,
       source: source ?? this.source,
       installId: installId ?? this.installId,
-      mostRecentApprovalDate:
-          mostRecentApprovalDate ?? this.mostRecentApprovalDate,
+      accessStatus: accessStatus ?? this.accessStatus,
+      ageRangeSource: ageRangeSource ?? this.ageRangeSource,
+      significantChangeStatus:
+          significantChangeStatus ?? this.significantChangeStatus,
+      significantChangeApprovalDate:
+          significantChangeApprovalDate ?? this.significantChangeApprovalDate,
     );
   }
 
@@ -99,7 +140,9 @@ class AgeSignalsMockData {
   String toString() {
     return 'AgeSignalsMockData(status: $status, ageLower: $ageLower, '
         'ageUpper: $ageUpper, source: $source, installId: $installId, '
-        'mostRecentApprovalDate: $mostRecentApprovalDate)';
+        'accessStatus: $accessStatus, ageRangeSource: $ageRangeSource, '
+        'significantChangeStatus: $significantChangeStatus, '
+        'significantChangeApprovalDate: $significantChangeApprovalDate)';
   }
 
   @override
@@ -112,8 +155,11 @@ class AgeSignalsMockData {
         other.ageUpper == ageUpper &&
         other.source == source &&
         other.installId == installId &&
-        other.mostRecentApprovalDate?.millisecondsSinceEpoch ==
-            mostRecentApprovalDate?.millisecondsSinceEpoch;
+        other.accessStatus == accessStatus &&
+        other.ageRangeSource == ageRangeSource &&
+        other.significantChangeStatus == significantChangeStatus &&
+        other.significantChangeApprovalDate?.millisecondsSinceEpoch ==
+            significantChangeApprovalDate?.millisecondsSinceEpoch;
   }
 
   @override
@@ -124,7 +170,10 @@ class AgeSignalsMockData {
       ageUpper,
       source,
       installId,
-      mostRecentApprovalDate?.millisecondsSinceEpoch,
+      accessStatus,
+      ageRangeSource,
+      significantChangeStatus,
+      significantChangeApprovalDate?.millisecondsSinceEpoch,
     );
   }
 }

--- a/lib/src/models/age_signals_result.dart
+++ b/lib/src/models/age_signals_result.dart
@@ -14,7 +14,9 @@ class AgeSignalsResult {
     this.source,
     this.installId,
     this.activeParentalControls,
-    this.mostRecentApprovalDate,
+    this.ageRangeSource,
+    this.significantChangeStatus,
+    this.significantChangeApprovalDate,
   });
 
   /// The verification status returned by the platform.
@@ -23,27 +25,33 @@ class AgeSignalsResult {
   /// The lower bound of the user's age range.
   ///
   /// On iOS, available when user consents to share age information.
-  /// On Android, available for supervised users (based on parental controls).
+  /// On Android, available whenever age signals are shared; verified 18+
+  /// users report the open-ended band (`ageLower: 18, ageUpper: null`).
   /// May be null if user declined (iOS) or if not available from the platform.
   final int? ageLower;
 
   /// The upper bound of the user's age range.
   ///
   /// On iOS, available when user consents to share age information.
-  /// On Android, available for supervised users (based on parental controls).
+  /// On Android, available whenever age signals are shared. Null for the
+  /// open-ended 18+ band on both platforms.
   /// May be null if user declined (iOS) or if not available from the platform.
   final int? ageUpper;
 
   /// The source of the age declaration (iOS only).
   ///
   /// Indicates whether the age was self-declared or declared by a guardian.
-  /// Only available on iOS when user consents to share.
+  /// Only available on iOS when user consents to share. Android reports how
+  /// an age range was established through [ageRangeSource] instead.
   final AgeDeclarationSource? source;
 
   /// Unique identifier for this app installation (Android only).
   ///
-  /// Can be used for compliance tracking and auditing purposes.
-  /// Only available on Android.
+  /// Reported for supervised users. When a parent revokes approval, Google
+  /// lists the id on the Play Console's Revoked app approvals tab as a CSV
+  /// download, retained for 90 days - so store it on your backend and
+  /// ingest revocations within that window if you need to act on them.
+  /// Google permits no other use. Only available on Android.
   final String? installId;
 
   /// Parental controls active on the user's account (iOS only).
@@ -55,13 +63,28 @@ class AgeSignalsResult {
   /// when Apple reports none.
   final List<String>? activeParentalControls;
 
-  /// When a guardian most recently approved the age range (Android only).
+  /// How Google Play established the age range (Android only).
   ///
-  /// Reported by the Play Age Signals API for supervised users. Useful for
-  /// deciding whether a cached signal is fresh enough. Values parsed from
-  /// the platform are UTC; equality compares the instant, not the time
-  /// zone. Null on iOS and when Google does not report it.
-  final DateTime? mostRecentApprovalDate;
+  /// The [status] is derived from this tier together with
+  /// [significantChangeStatus]. Null on iOS, and null on Android when age
+  /// signals are not shared or verification is still required.
+  final AgeRangeSource? ageRangeSource;
+
+  /// Parent approval state for significant app changes (Android only).
+  ///
+  /// Only supervised accounts carry this. Null on iOS, for unsupervised
+  /// users, and when no significant change has been recorded.
+  final SignificantChangeStatus? significantChangeStatus;
+
+  /// Effective date of the most recently approved significant change
+  /// (Android only).
+  ///
+  /// Reported by the Play Age Signals API for supervised users; when a
+  /// parent grants approval it moves to the newest approved change's
+  /// effective-from date. Values parsed from the platform are UTC; equality
+  /// compares the instant, not the time zone. Null on iOS and when Google
+  /// does not report it.
+  final DateTime? significantChangeApprovalDate;
 
   /// Creates a copy of this result with the given fields replaced with new values.
   AgeSignalsResult copyWith({
@@ -71,7 +94,9 @@ class AgeSignalsResult {
     AgeDeclarationSource? source,
     String? installId,
     List<String>? activeParentalControls,
-    DateTime? mostRecentApprovalDate,
+    AgeRangeSource? ageRangeSource,
+    SignificantChangeStatus? significantChangeStatus,
+    DateTime? significantChangeApprovalDate,
   }) {
     return AgeSignalsResult(
       status: status ?? this.status,
@@ -81,8 +106,11 @@ class AgeSignalsResult {
       installId: installId ?? this.installId,
       activeParentalControls:
           activeParentalControls ?? this.activeParentalControls,
-      mostRecentApprovalDate:
-          mostRecentApprovalDate ?? this.mostRecentApprovalDate,
+      ageRangeSource: ageRangeSource ?? this.ageRangeSource,
+      significantChangeStatus:
+          significantChangeStatus ?? this.significantChangeStatus,
+      significantChangeApprovalDate:
+          significantChangeApprovalDate ?? this.significantChangeApprovalDate,
     );
   }
 
@@ -91,7 +119,9 @@ class AgeSignalsResult {
     return 'AgeSignalsResult(status: $status, ageLower: $ageLower, '
         'ageUpper: $ageUpper, source: $source, installId: $installId, '
         'activeParentalControls: $activeParentalControls, '
-        'mostRecentApprovalDate: $mostRecentApprovalDate)';
+        'ageRangeSource: $ageRangeSource, '
+        'significantChangeStatus: $significantChangeStatus, '
+        'significantChangeApprovalDate: $significantChangeApprovalDate)';
   }
 
   @override
@@ -105,8 +135,10 @@ class AgeSignalsResult {
         other.source == source &&
         other.installId == installId &&
         listEquals(other.activeParentalControls, activeParentalControls) &&
-        other.mostRecentApprovalDate?.millisecondsSinceEpoch ==
-            mostRecentApprovalDate?.millisecondsSinceEpoch;
+        other.ageRangeSource == ageRangeSource &&
+        other.significantChangeStatus == significantChangeStatus &&
+        other.significantChangeApprovalDate?.millisecondsSinceEpoch ==
+            significantChangeApprovalDate?.millisecondsSinceEpoch;
   }
 
   @override
@@ -118,7 +150,9 @@ class AgeSignalsResult {
       source,
       installId,
       Object.hashAll(activeParentalControls ?? const []),
-      mostRecentApprovalDate?.millisecondsSinceEpoch,
+      ageRangeSource,
+      significantChangeStatus,
+      significantChangeApprovalDate?.millisecondsSinceEpoch,
     );
   }
 
@@ -139,7 +173,10 @@ class AgeSignalsResult {
         ?.map((e) => e as String)
         .toList();
 
-    final approvalMillis = map['mostRecentApprovalDate'] as int?;
+    final ageRangeSourceValue = map['ageRangeSource'];
+    final significantChangeStatusValue = map['significantChangeStatus'];
+
+    final approvalMillis = map['significantChangeApprovalDate'] as int?;
     final approvalDate = approvalMillis == null
         ? null
         : DateTime.fromMillisecondsSinceEpoch(approvalMillis, isUtc: true);
@@ -154,7 +191,13 @@ class AgeSignalsResult {
       source: source,
       installId: map['installId'] as String?,
       activeParentalControls: controls,
-      mostRecentApprovalDate: approvalDate,
+      ageRangeSource: ageRangeSourceValue is String
+          ? AgeRangeSource.fromName(ageRangeSourceValue)
+          : null,
+      significantChangeStatus: significantChangeStatusValue is String
+          ? SignificantChangeStatus.fromName(significantChangeStatusValue)
+          : null,
+      significantChangeApprovalDate: approvalDate,
     );
   }
 
@@ -167,7 +210,10 @@ class AgeSignalsResult {
       'source': source?.name,
       'installId': installId,
       'activeParentalControls': activeParentalControls,
-      'mostRecentApprovalDate': mostRecentApprovalDate?.millisecondsSinceEpoch,
+      'ageRangeSource': ageRangeSource?.name,
+      'significantChangeStatus': significantChangeStatus?.name,
+      'significantChangeApprovalDate':
+          significantChangeApprovalDate?.millisecondsSinceEpoch,
     };
   }
 }
@@ -176,15 +222,16 @@ class AgeSignalsResult {
 enum AgeSignalsStatus {
   /// User is verified as being over the age threshold.
   ///
-  /// On Android, this means the user's parental controls indicate they are
-  /// above the required age. On iOS, this is determined by the declared age
+  /// On Android, the age range was verified ([AgeRangeSource.tierC] or
+  /// [AgeRangeSource.tierD]). On iOS, this is determined by the declared age
   /// range relative to the configured age gates (e.g., highest gate met).
   verified,
 
   /// User's age could not be determined.
   ///
   /// This may occur when:
-  /// - User has not set up parental controls (Android)
+  /// - Age signals are not shared (Android; request access first, and note
+  ///   the user may have declined or may still need to verify)
   /// - Age verification data is not available
   /// - API is not available in the user's region
   unknown,
@@ -192,27 +239,30 @@ enum AgeSignalsStatus {
   /// User declined to share their age information (iOS only).
   ///
   /// On iOS, the user explicitly chose not to share their age range
-  /// with the app.
+  /// with the app. On Android, a decline surfaces as
+  /// `AgeSignalsAccessStatus.notShared` from the access request instead.
   declined,
 
   /// User is under parental supervision or below age threshold.
   ///
-  /// On Android, indicates the user is managed by parental controls
-  /// and may be below the required age threshold. On iOS, this value is
-  /// returned when the declared age range does not meet the configured gates.
+  /// On Android, the age range comes from a parent-managed account
+  /// ([AgeRangeSource.tierB]) with no pending or declined significant
+  /// change. On iOS, this value is returned when the declared age range
+  /// does not meet the configured gates.
   supervised,
 
-  /// User is supervised and awaiting guardian approval (Android only).
+  /// User is supervised and a parent approval is pending (Android only).
   ///
-  /// On Android, this indicates the user is under parental controls and
-  /// a request for access has been sent to the guardian, but the guardian
-  /// has not yet responded.
+  /// On Android, the account is parent-managed and the parent has not yet
+  /// approved the most recent significant change reported to Google Play
+  /// ([SignificantChangeStatus.pending]). Restrict the functionality behind
+  /// the change until it is approved.
   supervisedApprovalPending,
 
-  /// User is supervised and guardian denied approval (Android only).
+  /// User is supervised and a parent denied approval (Android only).
   ///
-  /// On Android, this indicates the user is under parental controls and
-  /// the guardian has explicitly denied the access request.
+  /// On Android, the account is parent-managed and the parent declined the
+  /// most recent significant change ([SignificantChangeStatus.declined]).
   ///
   /// iOS never returns this: DeclaredAgeRange has no denied state, so a
   /// guardian decline or consent revocation surfaces as [supervised] with
@@ -224,7 +274,7 @@ enum AgeSignalsStatus {
   /// User declared their age through Google Play (Android only).
   ///
   /// On Android, this indicates the user has self-declared their age
-  /// through Google Play's age declaration flow (available with age-signals 0.0.3+).
+  /// through Google Play's age declaration flow ([AgeRangeSource.tierA]).
   declared,
 }
 
@@ -235,4 +285,65 @@ enum AgeDeclarationSource {
 
   /// Age was declared by a guardian in Family Sharing.
   guardianDeclared,
+}
+
+/// How Google Play established the user's age range (Android only).
+///
+/// Reported by the Play Age Signals API since age-signals 0.0.4, ordered
+/// from weakest to strongest assurance. The tier vocabulary is Google's own;
+/// the exact verification methods behind each tier are defined by the Play
+/// Age Signals documentation and may evolve.
+enum AgeRangeSource {
+  /// The user self-declared their age through Google Play.
+  tierA,
+
+  /// The age range comes from a parent- or guardian-managed account.
+  ///
+  /// This is the supervised family: [AgeSignalsResult.status] reports
+  /// [AgeSignalsStatus.supervised], [AgeSignalsStatus.supervisedApprovalPending],
+  /// or [AgeSignalsStatus.supervisedApprovalDenied] depending on
+  /// [AgeSignalsResult.significantChangeStatus].
+  tierB,
+
+  /// Verified via credit card, email, selfie, government ID, or tax ID.
+  tierC,
+
+  /// Verified via government ID plus selfie, or a Digital ID.
+  tierD;
+
+  /// Parses a source name coming over the platform channel.
+  ///
+  /// Returns null for names this version does not know, so future Google
+  /// additions degrade gracefully instead of crashing the parse.
+  static AgeRangeSource? fromName(String name) =>
+      AgeRangeSource.values.asNameMap()[name];
+}
+
+/// Parent approval state for significant app changes (Android only).
+///
+/// Google Play notifies parents of supervised users about significant
+/// changes you report on the Age signals page of the Play Console. Approval
+/// is cumulative: one parent approval covers every change still pending
+/// since the last approval.
+enum SignificantChangeStatus {
+  /// The parent approved the most recent significant change(s).
+  approved,
+
+  /// A parent approval request is active but not yet answered.
+  ///
+  /// Restrict access to the functionality behind the change until the
+  /// parent approves it.
+  pending,
+
+  /// The parent denied the significant change(s).
+  ///
+  /// Restrict access to the functionality behind the declined changes.
+  declined;
+
+  /// Parses a status name coming over the platform channel.
+  ///
+  /// Returns null for names this version does not know, so future Google
+  /// additions degrade gracefully instead of crashing the parse.
+  static SignificantChangeStatus? fromName(String name) =>
+      SignificantChangeStatus.values.asNameMap()[name];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: age_range_signals
 description: Flutter plugin for age verification supporting Google Play Age Signals API (Android) and Apple's Age Range (DeclaredAgeRange) API (iOS 26+).
-version: 0.7.0
+version: 0.8.0
 homepage: https://github.com/zigapovhe/age_range_signals
 repository: https://github.com/zigapovhe/age_range_signals
 issue_tracker: https://github.com/zigapovhe/age_range_signals/issues

--- a/test/age_range_signals_method_channel_test.dart
+++ b/test/age_range_signals_method_channel_test.dart
@@ -15,6 +15,8 @@ void main() {
           switch (methodCall.method) {
             case 'initialize':
               return null;
+            case 'requestAgeSignalsAccess':
+              return 'shared';
             case 'checkAgeSignals':
               // Mock VERIFIED user (18+) - age values should be null
               return {
@@ -53,6 +55,56 @@ void main() {
       result.installId,
       null,
     ); // VERIFIED users typically don't have installId
+  });
+
+  test('requestAgeSignalsAccess parses the returned status', () async {
+    expect(
+      await platform.requestAgeSignalsAccess(),
+      AgeSignalsAccessStatus.shared,
+    );
+  });
+
+  test(
+    'requestAgeSignalsAccess maps unrecognized statuses to unknown',
+    () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+            return 'somethingNew';
+          });
+
+      expect(
+        await platform.requestAgeSignalsAccess(),
+        AgeSignalsAccessStatus.unknown,
+      );
+    },
+  );
+
+  test('requestAgeSignalsAccess handles a missing activity', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+          throw PlatformException(
+            code: 'PRESENTATION_CONTEXT_UNAVAILABLE',
+            message:
+                'No foreground activity to present the age sharing prompt on',
+          );
+        });
+
+    expect(
+      () => platform.requestAgeSignalsAccess(),
+      throwsA(isA<ApiErrorException>()),
+    );
+  });
+
+  test('requestAgeSignalsAccess rejects a null platform result', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+          return null;
+        });
+
+    expect(
+      () => platform.requestAgeSignalsAccess(),
+      throwsA(isA<AgeSignalsException>()),
+    );
   });
 
   test('checkAgeSignals returns supervised result with age ranges', () async {
@@ -146,7 +198,7 @@ void main() {
           throw PlatformException(
             code: 'SDK_VERSION_OUTDATED',
             message: 'Google Play Services version is outdated',
-            details: 'Requires version 0.0.3 or higher',
+            details: 'Requires version 0.0.4 or higher',
           );
         });
 

--- a/test/age_range_signals_test.dart
+++ b/test/age_range_signals_test.dart
@@ -8,6 +8,7 @@ class MockAgeRangeSignalsPlatform extends AgeRangeSignalsPlatform
     with MockPlatformInterfaceMixin {
   bool _initialized = false;
   List<int>? _ageGates;
+  AgeSignalsAccessStatus _accessStatus = AgeSignalsAccessStatus.shared;
 
   @override
   Future<void> initialize({
@@ -18,6 +19,10 @@ class MockAgeRangeSignalsPlatform extends AgeRangeSignalsPlatform
     _initialized = true;
     _ageGates = ageGates;
   }
+
+  @override
+  Future<AgeSignalsAccessStatus> requestAgeSignalsAccess() async =>
+      _accessStatus;
 
   @override
   Future<AgeSignalsResult> checkAgeSignals() async {
@@ -140,6 +145,19 @@ void main() {
       expect(
         () => AgeRangeSignals.instance.checkAgeSignals(),
         throwsA(isA<NotInitializedException>()),
+      );
+    });
+
+    test('requestAgeSignalsAccess delegates to the platform', () async {
+      expect(
+        await AgeRangeSignals.instance.requestAgeSignalsAccess(),
+        AgeSignalsAccessStatus.shared,
+      );
+
+      mockPlatform._accessStatus = AgeSignalsAccessStatus.notShared;
+      expect(
+        await AgeRangeSignals.instance.requestAgeSignalsAccess(),
+        AgeSignalsAccessStatus.notShared,
       );
     });
   });

--- a/test/age_signals_result_fields_test.dart
+++ b/test/age_signals_result_fields_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('AgeSignalsResult new fields', () {
     test(
-      'fromMap parses activeParentalControls and mostRecentApprovalDate',
+      'fromMap parses activeParentalControls and significantChangeApprovalDate',
       () {
         final result = AgeSignalsResult.fromMap({
           'status': 'supervised',
@@ -13,7 +13,7 @@ void main() {
           'source': null,
           'installId': 'abc',
           'activeParentalControls': ['communicationSafety', 'webContentFilter'],
-          'mostRecentApprovalDate': 1735689600000,
+          'significantChangeApprovalDate': 1735689600000,
         });
 
         expect(result.activeParentalControls, [
@@ -21,11 +21,39 @@ void main() {
           'webContentFilter',
         ]);
         expect(
-          result.mostRecentApprovalDate,
+          result.significantChangeApprovalDate,
           DateTime.fromMillisecondsSinceEpoch(1735689600000, isUtc: true),
         );
       },
     );
+
+    test('fromMap parses ageRangeSource and significantChangeStatus', () {
+      final result = AgeSignalsResult.fromMap({
+        'status': 'supervisedApprovalPending',
+        'ageLower': 13,
+        'ageUpper': 15,
+        'source': null,
+        'installId': 'abc',
+        'ageRangeSource': 'tierB',
+        'significantChangeStatus': 'pending',
+      });
+
+      expect(result.ageRangeSource, AgeRangeSource.tierB);
+      expect(result.significantChangeStatus, SignificantChangeStatus.pending);
+    });
+
+    test('fromMap leaves unknown tier and change-status names null', () {
+      // Future Google additions must degrade gracefully, not crash the parse.
+      final result = AgeSignalsResult.fromMap({
+        'status': 'verified',
+        'ageRangeSource': 'tierE',
+        'significantChangeStatus': 'escalated',
+      });
+
+      expect(result.status, AgeSignalsStatus.verified);
+      expect(result.ageRangeSource, isNull);
+      expect(result.significantChangeStatus, isNull);
+    });
 
     test('fromMap tolerates missing new keys (old native layer)', () {
       final result = AgeSignalsResult.fromMap({
@@ -37,7 +65,9 @@ void main() {
       });
 
       expect(result.activeParentalControls, isNull);
-      expect(result.mostRecentApprovalDate, isNull);
+      expect(result.ageRangeSource, isNull);
+      expect(result.significantChangeStatus, isNull);
+      expect(result.significantChangeApprovalDate, isNull);
     });
 
     test('toMap round-trips the new fields', () {
@@ -46,7 +76,9 @@ void main() {
         ageLower: 13,
         ageUpper: 15,
         activeParentalControls: const ['screenTime'],
-        mostRecentApprovalDate: DateTime.fromMillisecondsSinceEpoch(
+        ageRangeSource: AgeRangeSource.tierB,
+        significantChangeStatus: SignificantChangeStatus.approved,
+        significantChangeApprovalDate: DateTime.fromMillisecondsSinceEpoch(
           1735689600000,
           isUtc: true,
         ),
@@ -59,14 +91,14 @@ void main() {
     test('equality compares approval date instants across time zones', () {
       final utc = AgeSignalsResult(
         status: AgeSignalsStatus.supervised,
-        mostRecentApprovalDate: DateTime.fromMillisecondsSinceEpoch(
+        significantChangeApprovalDate: DateTime.fromMillisecondsSinceEpoch(
           1735689600000,
           isUtc: true,
         ),
       );
       final local = AgeSignalsResult(
         status: AgeSignalsStatus.supervised,
-        mostRecentApprovalDate: DateTime.fromMillisecondsSinceEpoch(
+        significantChangeApprovalDate: DateTime.fromMillisecondsSinceEpoch(
           1735689600000,
         ),
       );
@@ -81,33 +113,77 @@ void main() {
       const a = AgeSignalsResult(
         status: AgeSignalsStatus.supervised,
         activeParentalControls: ['screenTime'],
+        ageRangeSource: AgeRangeSource.tierB,
       );
-      final b = a.copyWith(activeParentalControls: ['screenTime', 'other']);
+      final b = a.copyWith(
+        significantChangeStatus: SignificantChangeStatus.pending,
+      );
 
       expect(a == b, isFalse);
-      expect(b.activeParentalControls, ['screenTime', 'other']);
+      expect(b.ageRangeSource, AgeRangeSource.tierB);
+      expect(b.significantChangeStatus, SignificantChangeStatus.pending);
       expect(b.status, AgeSignalsStatus.supervised);
     });
   });
 
-  group('AgeSignalsMockData mostRecentApprovalDate', () {
-    test('toMap emits epoch milliseconds', () {
+  group('AgeSignalsMockData 0.0.4 fields', () {
+    test('toMap emits epoch milliseconds for the approval date', () {
       final mock = AgeSignalsMockData(
         status: AgeSignalsStatus.supervised,
         ageLower: 13,
         ageUpper: 15,
-        mostRecentApprovalDate: DateTime.fromMillisecondsSinceEpoch(
+        significantChangeApprovalDate: DateTime.fromMillisecondsSinceEpoch(
           1735689600000,
           isUtc: true,
         ),
       );
 
-      expect(mock.toMap()['mostRecentApprovalDate'], 1735689600000);
+      expect(mock.toMap()['significantChangeApprovalDate'], 1735689600000);
     });
 
-    test('toMap emits null when unset', () {
+    test('toMap emits access status and explicit signal overrides', () {
+      const mock = AgeSignalsMockData(
+        status: AgeSignalsStatus.verified,
+        accessStatus: AgeSignalsAccessStatus.verificationRequired,
+        ageRangeSource: AgeRangeSource.tierD,
+        significantChangeStatus: SignificantChangeStatus.approved,
+      );
+
+      final map = mock.toMap();
+      expect(map['accessStatus'], 'verificationRequired');
+      expect(map['ageRangeSource'], 'tierD');
+      expect(map['significantChangeStatus'], 'approved');
+    });
+
+    test('toMap emits null for unset 0.0.4 fields', () {
       const mock = AgeSignalsMockData(status: AgeSignalsStatus.verified);
-      expect(mock.toMap()['mostRecentApprovalDate'], isNull);
+
+      final map = mock.toMap();
+      expect(map['accessStatus'], isNull);
+      expect(map['ageRangeSource'], isNull);
+      expect(map['significantChangeStatus'], isNull);
+      expect(map['significantChangeApprovalDate'], isNull);
+    });
+  });
+
+  group('AgeSignalsAccessStatus', () {
+    test('fromName parses every value and falls back to unknown', () {
+      expect(
+        AgeSignalsAccessStatus.fromName('shared'),
+        AgeSignalsAccessStatus.shared,
+      );
+      expect(
+        AgeSignalsAccessStatus.fromName('notShared'),
+        AgeSignalsAccessStatus.notShared,
+      );
+      expect(
+        AgeSignalsAccessStatus.fromName('verificationRequired'),
+        AgeSignalsAccessStatus.verificationRequired,
+      );
+      expect(
+        AgeSignalsAccessStatus.fromName('somethingNew'),
+        AgeSignalsAccessStatus.unknown,
+      );
     });
   });
 }


### PR DESCRIPTION
Google released age-signals 0.0.4 in July ([release notes](https://developer.android.com/google/play/age-signals/release-notes)) and it is a breaking update: `userStatus` is gone, `mostRecentApprovalDate` is renamed, and receiving signals now requires the two-function architecture (`requestAgeSignalsAccess()` before `checkAgeSignals()`). This PR migrates the plugin and proposes it as 0.8.0.

## Keeping the existing API working

0.0.4 replaces `userStatus` with `ageRangeSource` (tier A-D) + `significantChangeStatus` (approved/pending/declined). The Kotlin layer derives the existing `AgeSignalsStatus` vocabulary from that pair - tierB maps to the supervised family (refined by a pending or declined significant change), tierA to `declared`, tierC/tierD to `verified` - so status-based app code keeps working and iOS parity is untouched. The mock path applies the reverse mapping, so existing `AgeSignalsMockData` setups round-trip unchanged.

## New API

- `requestAgeSignalsAccess()` - may show Play's in-app age sharing prompt (the plugin now implements `ActivityAware` to present it) and returns `shared`, `notShared`, or `verificationRequired`. A decline is a result, not an error. On iOS it returns `shared`, since Apple gathers consent inside `checkAgeSignals()` itself; one call sequence works on both platforms.
- `AgeSignalsResult.ageRangeSource` and `.significantChangeStatus` are exposed as new fields.
- **Breaking**: `mostRecentApprovalDate` follows the upstream rename to `significantChangeApprovalDate` (result, mock data, and channel key).
- `AgeSignalsMockData` gains `accessStatus` plus explicit `ageRangeSource`/`significantChangeStatus` overrides.

## Testing

- Android unit tests cover the status derivation in both directions, the fake access results, and the error paths; run against the real 0.0.4 AAR.
- `flutter test` (66 tests), `flutter analyze`, and `dart format` are clean.
- Integration tests pass on an Android 17 emulator with Play Store: `requestAgeSignalsAccess()` goes through the full channel -> activity -> Play library path (the emulator's Play Store predates age-signals, so it surfaces the documented `-6` as a typed `PlayServicesException`).
- Docs cross-checked against the 0.0.4 guide pages (request-age-signals, understand-age-signals-responses, notify-significant-changes, revoked-app-approval).